### PR TITLE
Update install_deps.sh

### DIFF
--- a/make/install_deps.sh
+++ b/make/install_deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # usage: install_deps.sh install_dir
 #
 # if install_dir is not specified, it will install all deps in $ROOT/deps,

--- a/make/install_deps.sh
+++ b/make/install_deps.sh
@@ -4,7 +4,7 @@
 # if install_dir is not specified, it will install all deps in $ROOT/deps,
 #
 
-if [$# -ne 1]; then
+if [ $# -ne 1 ]; then
     install_dir=$PWD/`dirname $0`/../deps
 else
     install_dir=$1


### PR DESCRIPTION
This PR fixes a small bug in `make/install_deps.sh` (missing spaces around the condition of an if statement) and uses the version of `bash` on the user's `PATH`, rather than `/bin/bash`. On Mac OS, it is not advised to replace `/bin/bash`, but the version of `bash` that ships with Mac OS is too old to run this script without error.

If there is a better fix, please let me know :)