### PR TITLE
changes to allow ps-lite to build easily on OSX with homebrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,12 @@ ifndef DEPS_PATH
 DEPS_PATH = $(shell pwd)/deps
 endif
 
+ifndef PROTOC
+PROTOC = ${DEPS_PATH}/bin/protoc
+endif
+
 WARN = -Wall -finline-functions
-INCPATH = -I./src -I$(DEPS_PATH)/include
+INCPATH = -I./src -I$(DEPS_PATH)/include $(EXTRA_INCLUDES)
 CFLAGS = -std=c++11 -msse2 $(WARN) $(OPT) $(INCPATH) $(PS_CFLAGS) $(EXTRA_CFLAGS)
 
 PS_LIB = build/libps.a
@@ -49,7 +53,7 @@ build/%.o: src/%.cc
 	$(CXX) $(CFLAGS) -c $< -o $@
 
 %.pb.cc %.pb.h : %.proto
-	${DEPS_PATH}/bin/protoc --cpp_out=./src --proto_path=./src $<
+	$(PROTOC) --cpp_out=./src --proto_path=./src $<
 
 -include build/*/*.d
 -include build/*/*/*.d

--- a/src/filter/add_noise.h
+++ b/src/filter/add_noise.h
@@ -1,5 +1,9 @@
 #pragma once
 #include "filter/filter.h"
+#ifdef __MACH__
+#include <random>
+#endif
+
 namespace ps {
 
 /**

--- a/src/filter/compressing.h
+++ b/src/filter/compressing.h
@@ -2,6 +2,10 @@
 #include "filter/filter.h"
 #include <lz4.h>
 
+#if __LZ4_VERSION_MINOR__ < 7
+#define LZ4_compress_default LZ4_compress_limitedOutput
+#endif
+
 namespace ps {
 
 class CompressingFilter : public IFilter {

--- a/src/system/van.cc
+++ b/src/system/van.cc
@@ -8,6 +8,11 @@
 #include "ps/shared_array.h"
 #include "system/manager.h"
 #include "system/postoffice.h"
+
+#ifndef ZMQ_IDENTITY_FD
+#define ZMQ_IDENTITY_FD ZMQ_FD
+#endif
+
 namespace ps {
 DEFINE_int32(bind_to, 0, "binding port");
 DEFINE_bool(local, false, "run in local");


### PR DESCRIPTION
Thanks for the fantastic library! A few changes to support OSX and dependencies form homebrew:

* Add configurable path to protoc binary.
* Drop in replacement for clock_gettime on OSX.
* Support LZ4 1.5, which ships with homebrew.
* Support more recent ZeroMQ that ships with homebrew. 
