### PR TITLE
ensure workers are launched in order

### DIFF
--- a/tracker/dmlc_ssh.py
+++ b/tracker/dmlc_ssh.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import tracker
 import logging
+import time
 from threading import Thread
 
 class SSHLauncher(object):
@@ -80,6 +81,7 @@ class SSHLauncher(object):
                 thread = Thread(target = run, args=(prog,))
                 thread.setDaemon(True)
                 thread.start()
+                time.sleep(5) # wait until the worker goes online.
 
         return ssh_submit
 


### PR DESCRIPTION
The original code is problematic when one needs to stop the training process and resume afterwards, because the workers are in random order, after resuming the order may change and fail to find the checkpoint.