### PR TITLE
Get host/ip from env.

### DIFF
--- a/src/van.cc
+++ b/src/van.cc
@@ -33,18 +33,22 @@ void Van::Start() {
   } else {
     auto role = is_scheduler_ ? Node::SCHEDULER :
                 (Postoffice::Get()->is_worker() ? Node::WORKER : Node::SERVER);
-    std::string interface;
-    const char*  itf = getenv("DMLC_INTERFACE");
-    if (itf) interface = std::string(itf);
+    const char* nhost = getenv("DMLC_NODE_HOST");
     std::string ip;
-    if (interface.size()) {
-      GetIP(interface, &ip);
-    } else {
-      GetAvailableInterfaceAndIP(&interface, &ip);
+    if (nhost) ip = std::string(nhost);
+    if (ip.empty()) {
+      const char*  itf = getenv("DMLC_INTERFACE");
+      std::string interface;
+      if (itf) interface = std::string(itf);
+      if (interface.size()) {
+        GetIP(interface, &ip);
+      } else {
+        GetAvailableInterfaceAndIP(&interface, &ip);
+      }
+      CHECK(!interface.empty()) << "failed to get the interface";
     }
     int port = GetAvailablePort();
     CHECK(!ip.empty()) << "failed to get ip";
-    CHECK(!interface.empty()) << "failed to get the interface";
     CHECK(port) << "failed to get a port";
     my_node_.hostname = ip;
     my_node_.role     = role;


### PR DESCRIPTION
This is in addition to https://github.com/dmlc/dmlc-core/pull/110.

The host/ip got from network adaptor info in network_util.h is not necessarily reachable from outside the node/container when the networks are unidentically or malformedly configured. We can specify a host/ip that is guaranteed to be accessible from outside the container/node which is typically provided by the cluster management module like https://github.com/dmlc/dmlc-core/pull/110.

If the env variable "DMLC_NODE_HOST" is not specified, the program falls back to the previous implementation of querying network interface and getting the ip.