### PR TITLE
support PORT env for docker

### DIFF
--- a/src/van.cc
+++ b/src/van.cc
@@ -52,6 +52,8 @@ void Van::Start() {
       CHECK(!interface.empty()) << "failed to get the interface";
     }
     int port = GetAvailablePort();
+    const char* pstr = Environment::Get()->find("PORT");
+    if (pstr) port = atoi(pstr);
     CHECK(!ip.empty()) << "failed to get ip";
     CHECK(port) << "failed to get a port";
     my_node_.hostname = ip;


### PR DESCRIPTION
In marathon, it will generate a random port for every docker container and pass to container through env var $PORT.

I do not know if this change is too hack. If you have better suggestions, I can change it.