### PR TITLE
Support recovery nodes

### DIFF
--- a/include/ps/internal/message.h
+++ b/include/ps/internal/message.h
@@ -65,6 +65,15 @@ struct Node {
   static const int kEmpty;
   /** \brief default constructor */
   Node() : id(kEmpty), port(kEmpty), is_recovery(false) {}
+  /** \brief copy constructor */
+  Node(const Node &ref)
+    : role(ref.role), id(ref.id), hostname(ref.hostname),
+      port(ref.port), is_recovery(static_cast<bool>(ref.is_recovery)) {}
+  /** \brief = operator overload */
+  Node& operator=(Node other) {
+    std::swap(other, *this);
+    return *this;
+  }
   /** \brief node roles */
   enum Role { SERVER, WORKER, SCHEDULER };
   /** \brief get debug string */
@@ -91,7 +100,7 @@ struct Node {
   /** \brief the port this node is binding */
   int port;
   /** \brief whether this node is created by failover */
-  bool is_recovery;
+  std::atomic<bool> is_recovery;
 };
 /**
  * \brief meta info of a system control message

--- a/include/ps/internal/message.h
+++ b/include/ps/internal/message.h
@@ -7,6 +7,7 @@
 #include <limits>
 #include <string>
 #include <sstream>
+#include <atomic>
 #include "ps/sarray.h"
 namespace ps {
 /** \brief data type */

--- a/include/ps/internal/message.h
+++ b/include/ps/internal/message.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <sstream>
 #include <atomic>
+#include <algorithm>
 #include "ps/sarray.h"
 namespace ps {
 /** \brief data type */
@@ -67,12 +68,18 @@ struct Node {
   /** \brief default constructor */
   Node() : id(kEmpty), port(kEmpty), is_recovery(false) {}
   /** \brief copy constructor */
-  Node(const Node &ref)
-    : role(ref.role), id(ref.id), hostname(ref.hostname),
-      port(ref.port), is_recovery(static_cast<bool>(ref.is_recovery)) {}
+  Node(const Node &other) : role(other.role), id(other.id),
+    hostname(other.hostname), port(other.port),
+    is_recovery(static_cast<bool>(other.is_recovery)) {}
   /** \brief = operator overload */
-  Node& operator=(Node other) {
-    std::swap(other, *this);
+  Node& operator=(const Node& other) {
+    if (this != &other) {
+      role = other.role;
+      id = other.id;
+      hostname = other.hostname;
+      port = other.port;
+      is_recovery = static_cast<bool>(other.is_recovery);
+    }
     return *this;
   }
   /** \brief node roles */

--- a/include/ps/internal/message.h
+++ b/include/ps/internal/message.h
@@ -7,8 +7,6 @@
 #include <limits>
 #include <string>
 #include <sstream>
-#include <atomic>
-#include <algorithm>
 #include "ps/sarray.h"
 namespace ps {
 /** \brief data type */
@@ -67,21 +65,6 @@ struct Node {
   static const int kEmpty;
   /** \brief default constructor */
   Node() : id(kEmpty), port(kEmpty), is_recovery(false) {}
-  /** \brief copy constructor */
-  Node(const Node &other) : role(other.role), id(other.id),
-    hostname(other.hostname), port(other.port),
-    is_recovery(static_cast<bool>(other.is_recovery)) {}
-  /** \brief = operator overload */
-  Node& operator=(const Node& other) {
-    if (this != &other) {
-      role = other.role;
-      id = other.id;
-      hostname = other.hostname;
-      port = other.port;
-      is_recovery = static_cast<bool>(other.is_recovery);
-    }
-    return *this;
-  }
   /** \brief node roles */
   enum Role { SERVER, WORKER, SCHEDULER };
   /** \brief get debug string */
@@ -108,7 +91,7 @@ struct Node {
   /** \brief the port this node is binding */
   int port;
   /** \brief whether this node is created by failover */
-  std::atomic<bool> is_recovery;
+  bool is_recovery;
 };
 /**
  * \brief meta info of a system control message

--- a/include/ps/internal/message.h
+++ b/include/ps/internal/message.h
@@ -64,7 +64,7 @@ struct Node {
   /** \brief the empty value */
   static const int kEmpty;
   /** \brief default constructor */
-  Node() : id(kEmpty), port(kEmpty) {}
+  Node() : id(kEmpty), port(kEmpty), is_recovery(false) {}
   /** \brief node roles */
   enum Role { SERVER, WORKER, SCHEDULER };
   /** \brief get debug string */
@@ -72,7 +72,7 @@ struct Node {
     std::stringstream ss;
     ss << "role=" << (role == SERVER ? "server" : (role == WORKER ? "worker" : "scheduler"))
        << (id != kEmpty ? ", id=" + std::to_string(id) : "")
-       << ", ip=" << hostname << ", port=" << port;
+       << ", ip=" << hostname << ", port=" << port << ", is_recovery=" << is_recovery;
 
     return ss.str();
   }
@@ -90,6 +90,8 @@ struct Node {
   std::string hostname;
   /** \brief the port this node is binding */
   int port;
+  /** \brief whether this node is created by failover */
+  bool is_recovery;
 };
 /**
  * \brief meta info of a system control message

--- a/include/ps/internal/postoffice.h
+++ b/include/ps/internal/postoffice.h
@@ -158,10 +158,6 @@ class Postoffice {
    * \param t timeout in sec
    */
   std::vector<int> GetDeadNodes(int t = 60);
-  /**
-   * \brief force to release the barrier
-   */
-  void ForceReleaseBarrier();
 
  private:
   Postoffice();

--- a/include/ps/internal/postoffice.h
+++ b/include/ps/internal/postoffice.h
@@ -28,9 +28,10 @@ class Postoffice {
    * \brief start the system
    *
    * This function will block until every nodes are started.
-   * \param argv0 the program name, used for logging
+   * \param argv0 the program name, used for logging.
+   * \param do_barrier whether to block until every nodes are started.
    */
-  void Start(const char* argv0);
+  void Start(const char* argv0, const bool do_barrier);
   /**
    * \brief terminate the system
    *

--- a/include/ps/internal/postoffice.h
+++ b/include/ps/internal/postoffice.h
@@ -132,6 +132,8 @@ class Postoffice {
   int is_scheduler() const { return is_scheduler_; }
   /** \brief Returns the verbose level. */
   int verbose() const { return verbose_; }
+  /** \brief Return whether this node is a recovery node */
+  bool is_recovery() const { return van_->my_node().is_recovery; }
   /**
    * \brief barrier
    * \param node_id the barrier group id

--- a/include/ps/ps.h
+++ b/include/ps/ps.h
@@ -35,7 +35,16 @@ inline int MyRank() { return Postoffice::Get()->my_rank(); }
  * \param argv0 the program name, used for logging
  */
 inline void Start(const char* argv0 = nullptr) {
-  Postoffice::Get()->Start(argv0);
+  Postoffice::Get()->Start(argv0, true);
+}
+/**
+ * \brief start the system
+ *
+ * This function will NOT block.
+ * \param argv0 the program name, used for logging
+ */
+inline void StartAsync(const char* argv0 = nullptr) {
+  Postoffice::Get()->Start(argv0, false);
 }
 /**
  * \brief terminate the system

--- a/src/meta.proto
+++ b/src/meta.proto
@@ -13,6 +13,8 @@ message PBNode {
   optional string hostname = 3;
   // the port this node is binding
   optional int32 port = 4;
+  // whether this node is created by failover
+  optional bool is_recovery = 5;
 }
 
 // system control info

--- a/src/postoffice.cc
+++ b/src/postoffice.cc
@@ -63,8 +63,7 @@ void Postoffice::Start(const char* argv0) {
   // record start time
   start_time_ = time(NULL);
 
-  // do a barrier here
-  //Barrier(kWorkerGroup + kServerGroup + kScheduler);
+  // leave application to decide whether to do a barrier here
 }
 
 void Postoffice::Finalize() {

--- a/src/postoffice.cc
+++ b/src/postoffice.cc
@@ -64,7 +64,7 @@ void Postoffice::Start(const char* argv0) {
   start_time_ = time(NULL);
 
   // do a barrier here
-  Barrier(kWorkerGroup + kServerGroup + kScheduler);
+  //Barrier(kWorkerGroup + kServerGroup + kScheduler);
 }
 
 void Postoffice::Finalize() {

--- a/src/postoffice.cc
+++ b/src/postoffice.cc
@@ -25,7 +25,7 @@ Postoffice::Postoffice() {
   verbose_ = GetEnv("PS_VERBOSE", 0);
 }
 
-void Postoffice::Start(const char* argv0) {
+void Postoffice::Start(const char* argv0, const bool do_barrier) {
   // init glog
   if (argv0) {
     dmlc::InitLogging(argv0);
@@ -63,7 +63,8 @@ void Postoffice::Start(const char* argv0) {
   // record start time
   start_time_ = time(NULL);
 
-  // leave application to decide whether to do a barrier here
+  // do a barrier here
+  if (do_barrier) Barrier(kWorkerGroup + kServerGroup + kScheduler);
 }
 
 void Postoffice::Finalize() {

--- a/src/van.cc
+++ b/src/van.cc
@@ -165,7 +165,7 @@ void Van::Receiving() {
       } else if (ctrl.cmd == Control::ADD_NODE) {
         size_t num_nodes = Postoffice::Get()->num_servers() +
                            Postoffice::Get()->num_workers();
-        Meta recovery_nodes; // store recovery nodes
+        Meta recovery_nodes;  // store recovery nodes
         recovery_nodes.control.cmd = Control::ADD_NODE;
         // assign an id
         if (msg.meta.sender == Meta::kEmpty) {
@@ -174,6 +174,8 @@ void Van::Receiving() {
           if (nodes.control.node.size() < num_nodes) {
             nodes.control.node.push_back(ctrl.node[0]);
           } else {
+            // some node dies and restarts
+            CHECK(ready_);
             auto dead_nodes = Postoffice::Get()->GetDeadNodes(heartbeat_timeout);
             std::unordered_set<int> dead_set(dead_nodes.begin(), dead_nodes.end());
             for (size_t i = 0; i < nodes.control.node.size() - 1; ++i) {

--- a/src/van.cc
+++ b/src/van.cc
@@ -60,6 +60,8 @@ void Van::Start() {
     my_node_.role     = role;
     my_node_.port     = port;
     // cannot determine my id now, the scheduler will assign it later
+    // set it explicitly to make re-register within a same process possible
+    my_node_.id = Node::kEmpty;
   }
 
   // bind.


### PR DESCRIPTION
* Check the dead node list and accept a new node which match the role of the one who is 'dead'. Mark this node as 'recovery'
* Doing Barrier is nonsense for a recovery node, I provide an async version of Start()

Related to https://github.com/dmlc/mxnet/issues/2268

With this feature, I'll make a PR for MXNet to support executor failover on Spark.