### PR TITLE
allow ps process to exit without barrier

### DIFF
--- a/include/ps/internal/postoffice.h
+++ b/include/ps/internal/postoffice.h
@@ -35,10 +35,10 @@ class Postoffice {
   /**
    * \brief terminate the system
    *
-   * All nodes should call this function before existing. It will block until
-   * every node is finalized.
+   * All nodes should call this function before existing. 
+   * \param do_barrier whether to do block until every node is finalized, default true.
    */
-  void Finalize();
+  void Finalize(const bool do_barrier = true);
   /**
    * \brief add an customer to the system. threadsafe
    */

--- a/include/ps/ps.h
+++ b/include/ps/ps.h
@@ -49,11 +49,11 @@ inline void StartAsync(const char* argv0 = nullptr) {
 /**
  * \brief terminate the system
  *
- * All nodes should call this function before existing. It will block until
- * every node is finalized.
+ * All nodes should call this function before existing. 
+ * \param do_barrier whether to block until every node is finalized, default true.
  */
-inline void Finalize() {
-  Postoffice::Get()->Finalize();
+inline void Finalize(const bool do_barrier = true) {
+  Postoffice::Get()->Finalize(do_barrier);
 }
 /**
  * \brief Register a callback to the system which is called after Finalize()

--- a/src/postoffice.cc
+++ b/src/postoffice.cc
@@ -67,8 +67,8 @@ void Postoffice::Start(const char* argv0, const bool do_barrier) {
   if (do_barrier) Barrier(kWorkerGroup + kServerGroup + kScheduler);
 }
 
-void Postoffice::Finalize() {
-  Barrier(kWorkerGroup + kServerGroup + kScheduler);
+void Postoffice::Finalize(const bool do_barrier) {
+  if (do_barrier) Barrier(kWorkerGroup + kServerGroup + kScheduler);
   van_->Stop();
   if (exit_callback_) exit_callback_();
 }


### PR DESCRIPTION
Related to https://github.com/dmlc/mxnet/issues/2268

When spark executor fails, java object (kvstore) may be garbage collected and cause destructor to be called. Thus we have to find a way to exit without barrier. Because otherwise servers and scheduler will also reach this barrier and exit.