### PR TITLE
explicitly add sender to message and check_eq between zmq_identify_id and sender_id

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.7)
 
 project(pslite C CXX)
 
+set(CMAKE_PREFIX_PATH deps)
+
 if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
@@ -56,5 +58,5 @@ list(APPEND pslite_LINKER_LIBS_L ${PROTOBUF_LIBRARIES})
 list(APPEND pslite_INCLUDE_DIR_L "${PROJECT_SOURCE_DIR}/include")
 list(APPEND pslite_INCLUDE_DIR_L ${PROTOBUF_INCLUDE_DIR})
 
-set(pslite_LINKER_LIBS ${pslite_LINKER_LIBS_L} PARENT_SCOPE)
-set(pslite_INCLUDE_DIR ${pslite_INCLUDE_DIR_L} PARENT_SCOPE)
+set(pslite_LINKER_LIBS ${pslite_LINKER_LIBS_L})
+set(pslite_INCLUDE_DIR ${pslite_INCLUDE_DIR_L})

--- a/cmake/ProtoBuf.cmake
+++ b/cmake/ProtoBuf.cmake
@@ -2,7 +2,7 @@
 # the standard cmake script with version and python generation support
 
 find_package( Protobuf REQUIRED )
-include_directories(SYSTEM ${PROTOBUF_INCLUDE_DIR})
+include_directories(SYSTEM ${PROTOBUF_INCLUDE_DIRS})
 list(APPEND pslite_LINKER_LIBS ${PROTOBUF_LIBRARIES})
 
 # As of Ubuntu 14.04 protoc is no longer a part of libprotobuf-dev package
@@ -12,7 +12,6 @@ if(EXISTS ${PROTOBUF_PROTOC_EXECUTABLE})
 else()
   message(FATAL_ERROR "Could not find PROTOBUF Compiler")
 endif()
-
 
 # place where to generate protobuf sources
 set(proto_gen_folder "${PROJECT_BINARY_DIR}/include/pslite/proto")
@@ -66,7 +65,7 @@ function(pslite_protobuf_generate_cpp_py output_dir srcs_var hdrs_var python_var
     list(APPEND ${srcs_var} "${o_fil_path}/${fil_we}.pb.cc")
     list(APPEND ${hdrs_var} "${o_fil_path}/${fil_we}.pb.h")
     list(APPEND ${python_var} "${o_fil_path}/${fil_we}_pb2.py")
-	
+
     add_custom_command(
       OUTPUT "${o_fil_path}/${fil_we}.pb.cc"
              "${o_fil_path}/${fil_we}.pb.h"

--- a/include/ps/internal/assign_op.h
+++ b/include/ps/internal/assign_op.h
@@ -14,7 +14,7 @@ enum AssignOp {
   PLUS,    // a += b
   MINUS,   // a -= b
   TIMES,   // a *= b
-  DIVIDE,  // a -= b
+  DIVIDE,  // a /= b
   AND,     // a &= b
   OR,      // a |= b
   XOR      // a ^= b

--- a/include/ps/internal/utils.h
+++ b/include/ps/internal/utils.h
@@ -39,7 +39,7 @@ inline V GetEnv(const char *key, V default_val) {
 #ifndef DISALLOW_COPY_AND_ASSIGN
 #define DISALLOW_COPY_AND_ASSIGN(TypeName) \
   TypeName(const TypeName&);               \
-  void operator=(const TypeName&)
+  void operator=(const TypeName&);
 #endif
 
 #define LL LOG(ERROR)

--- a/include/ps/kv_app.h
+++ b/include/ps/kv_app.h
@@ -392,6 +392,7 @@ void KVServer<Val>::Response(const KVMeta& req, const KVPairs<Val>& res) {
   msg.meta.head        = req.cmd;
   msg.meta.timestamp   = req.timestamp;
   msg.meta.recver      = req.sender;
+  msg.meta.sender = Postoffice::Get()->van()->my_node().id;
   if (res.keys.size()) {
     msg.AddData(res.keys);
     msg.AddData(res.vals);
@@ -485,6 +486,7 @@ void KVWorker<Val>::Send(int timestamp, bool push, int cmd, const KVPairs<Val>& 
     msg.meta.head        = cmd;
     msg.meta.timestamp   = timestamp;
     msg.meta.recver      = Postoffice::Get()->ServerRankToID(i);
+    msg.meta.sender = Postoffice::Get()->van()->my_node().id;
     const auto& kvs = s.second;
     if (kvs.keys.size()) {
       msg.AddData(kvs.keys);
@@ -545,7 +547,7 @@ template <typename C, typename D>
 int KVWorker<Val>::Pull_(
     const SArray<Key>& keys, C* vals, D* lens, int cmd, const Callback& cb) {
   int ts = obj_->NewRequest(kServerGroup);
-  AddCallback(ts, [this, ts, keys, vals, lens, cb]() mutable {
+  AddCallback(ts, [this, ts, keys, vals, lens, cb]() mutable {  
       mu_.lock();
       auto& kvs = recv_kvs_[ts];
       mu_.unlock();

--- a/include/ps/simple_app.h
+++ b/include/ps/simple_app.h
@@ -155,6 +155,7 @@ inline void SimpleApp::Response(const SimpleData& req, const std::string& res_bo
   msg.meta.simple_app = true;
   msg.meta.customer_id = obj_->id();
   msg.meta.recver = req.sender;
+  msg.meta.sender = Postoffice::Get()->van()->my_node().id;
 
   // send
   Postoffice::Get()->van()->Send(msg);

--- a/include/ps/simple_app.h
+++ b/include/ps/simple_app.h
@@ -135,6 +135,7 @@ inline int SimpleApp::Request(int req_head, const std::string& req_body, int rec
   msg.meta.request = true;
   msg.meta.simple_app = true;
   msg.meta.customer_id = obj_->id();
+  msg.meta.sender = Postoffice::Get()->van().my_node.id;
 
   // send
   for (int r : Postoffice::Get()->GetNodeIDs(recv_id)) {

--- a/include/ps/simple_app.h
+++ b/include/ps/simple_app.h
@@ -135,7 +135,7 @@ inline int SimpleApp::Request(int req_head, const std::string& req_body, int rec
   msg.meta.request = true;
   msg.meta.simple_app = true;
   msg.meta.customer_id = obj_->id();
-  msg.meta.sender = Postoffice::Get()->van().my_node().id;
+  msg.meta.sender = Postoffice::Get()->van()->my_node().id;
 
   // send
   for (int r : Postoffice::Get()->GetNodeIDs(recv_id)) {

--- a/include/ps/simple_app.h
+++ b/include/ps/simple_app.h
@@ -135,7 +135,7 @@ inline int SimpleApp::Request(int req_head, const std::string& req_body, int rec
   msg.meta.request = true;
   msg.meta.simple_app = true;
   msg.meta.customer_id = obj_->id();
-  msg.meta.sender = Postoffice::Get()->van().my_node.id;
+  msg.meta.sender = Postoffice::Get()->van().my_node().id;
 
   // send
   for (int r : Postoffice::Get()->GetNodeIDs(recv_id)) {

--- a/src/meta.proto
+++ b/src/meta.proto
@@ -37,13 +37,17 @@ message PBMeta {
   // false: the response task to the request task with the same *time*
   optional bool request = 4 [default = false];
   // the unique id of an customer
-  optional int32 customer_id = 7;
+  optional int32 customer_id = 5;
   // the timestamp of this message
-  optional int32 timestamp = 8;
+  optional int32 timestamp = 6;
   // data type of message.data[i]
-  repeated int32 data_type = 9 [packed=true];
+  repeated int32 data_type = 7 [packed=true];
   // whether or not a push message
-  optional bool push = 5;
+  optional bool push = 8;
   // whether or not it's for SimpleApp
-  optional bool simple_app = 6 [default = false];
+  optional bool simple_app = 9 [default = false];
+  // sender id
+  optional int32 sender = 10;
+  // recver id
+  optional int32 recver = 11;
 }

--- a/src/postoffice.cc
+++ b/src/postoffice.cc
@@ -120,6 +120,7 @@ void Postoffice::Barrier(int node_group) {
   std::unique_lock<std::mutex> ulk(barrier_mu_);
   barrier_done_ = false;
   Message req;
+  req.meta.sender = van_->my_node().id;
   req.meta.recver = kScheduler;
   req.meta.request = true;
   req.meta.control.cmd = Control::BARRIER;

--- a/src/postoffice.cc
+++ b/src/postoffice.cc
@@ -7,6 +7,7 @@
 #include "ps/internal/postoffice.h"
 #include "ps/internal/message.h"
 #include "ps/base.h"
+#include "ps/internal/utils.h"
 
 namespace ps {
 Postoffice::Postoffice() {

--- a/src/van.cc
+++ b/src/van.cc
@@ -369,7 +369,8 @@ void Van::PackMeta(const Meta& meta, char** meta_buf, int* buf_size) {
 
   // to string
   *buf_size = pb.ByteSize();
-  *meta_buf = new char[*buf_size+1];
+  //*meta_buf = new char[*buf_size+1];
+  *meta_buf = new char[*buf_size];
   CHECK(pb.SerializeToArray(*meta_buf, *buf_size))
       << "failed to serialize protbuf";
 }

--- a/src/van.cc
+++ b/src/van.cc
@@ -41,8 +41,7 @@ void Van::Start() {
   if (is_scheduler_) {
     my_node_ = scheduler_;
   } else {
-    auto role = is_scheduler_ ? Node::SCHEDULER :
-                (Postoffice::Get()->is_worker() ? Node::WORKER : Node::SERVER);
+    auto role = Postoffice::Get()->is_worker() ? Node::WORKER : Node::SERVER;
     const char* nhost = Environment::Get()->find("DMLC_NODE_HOST");
     std::string ip;
     if (nhost) ip = std::string(nhost);

--- a/src/van.cc
+++ b/src/van.cc
@@ -119,6 +119,7 @@ void Van::Stop() {
   // stop threads
   Message exit;
   exit.meta.control.cmd = Control::TERMINATE;
+  exit.meta.sender = my_node_.id;
   exit.meta.recver = my_node_.id;
   SendMsg(exit);
   receiver_thread_->join();
@@ -240,7 +241,9 @@ void Van::Receiving() {
             }
             nodes.control.node.push_back(my_node_);
             nodes.control.cmd = Control::ADD_NODE;
-            Message back; back.meta = nodes;
+            Message back; 
+            back.meta = nodes;
+            back.meta.sender = my_node_.id;
             for (int r : Postoffice::Get()->GetNodeIDs(
                      kWorkerGroup + kServerGroup)) {
               back.meta.recver = r;
@@ -256,6 +259,7 @@ void Van::Receiving() {
             Connect(recovery_nodes.control.node[0]);
             Postoffice::Get()->UpdateHeartbeat(recovery_nodes.control.node[0].id, t);
             Message back;
+            back.meta.sender = my_node_.id;
             for (int r : Postoffice::Get()->GetNodeIDs(
                      kWorkerGroup + kServerGroup)) {
               if (r != recovery_nodes.control.node[0].id
@@ -294,6 +298,7 @@ void Van::Receiving() {
             Message res;
             res.meta.request = false;
             res.meta.control.cmd = Control::BARRIER;
+            res.meta.sender = my_node_.id;
             for (int r : Postoffice::Get()->GetNodeIDs(group)) {
               res.meta.recver = r;
               res.meta.timestamp = timestamp_++;
@@ -309,6 +314,7 @@ void Van::Receiving() {
           Postoffice::Get()->UpdateHeartbeat(node.id, t);
           if (is_scheduler_) {
             Message heartbeat_ack;
+            heartbeat_ack.meta.sender = my_node_.id;
             heartbeat_ack.meta.recver = node.id;
             heartbeat_ack.meta.control.cmd = Control::HEARTBEAT;
             heartbeat_ack.meta.control.node.push_back(my_node_);
@@ -340,6 +346,8 @@ void Van::PackMeta(const Meta& meta, char** meta_buf, int* buf_size) {
   pb.set_push(meta.push);
   pb.set_request(meta.request);
   pb.set_simple_app(meta.simple_app);
+  if (meta.sender != Meta::kEmpty) pb.set_sender(meta.sender);
+  if (meta.recver != Meta::kEmpty) pb.set_recver(meta.recver);
   for (auto d : meta.data_type) pb.add_data_type(d);
   if (!meta.control.empty()) {
     auto ctrl = pb.mutable_control();
@@ -380,6 +388,8 @@ void Van::UnpackMeta(const char* meta_buf, int buf_size, Meta* meta) {
   meta->push = pb.push();
   meta->simple_app = pb.simple_app();
   meta->body = pb.body();
+  meta->sender = pb.has_sender() ? pb.sender() : Meta::kEmpty;
+  meta->recver = pb.has_recver()? pb.recver() : Meta::kEmpty;
   meta->data_type.resize(pb.data_type_size());
   for (int i = 0; i < pb.data_type_size(); ++i) {
     meta->data_type[i] = static_cast<DataType>(pb.data_type(i));
@@ -410,6 +420,7 @@ void Van::Heartbeat() {
   while (interval > 0 && ready_) {
     std::this_thread::sleep_for(std::chrono::seconds(interval));
     Message msg;
+    msg.meta.sender = my_node_.id;
     msg.meta.recver = kScheduler;
     msg.meta.control.cmd = Control::HEARTBEAT;
     msg.meta.control.node.push_back(my_node_);

--- a/tests/local.sh
+++ b/tests/local.sh
@@ -19,7 +19,6 @@ export DMLC_PS_ROOT_PORT=8000
 export DMLC_ROLE='scheduler'
 ${bin} ${arg} &
 
-
 # start servers
 export DMLC_ROLE='server'
 for ((i=0; i<${DMLC_NUM_SERVER}; ++i)); do

--- a/tests/test_kv_app.cc
+++ b/tests/test_kv_app.cc
@@ -13,7 +13,7 @@ void RunWorker() {
   KVWorker<float> kv(0);
 
   // init
-  int num = 10000;
+  int num = 10;
   std::vector<Key> keys(num);
   std::vector<float> vals(num);
 
@@ -22,6 +22,7 @@ void RunWorker() {
   for (int i = 0; i < num; ++i) {
     keys[i] = kMaxKey / num * i + rank;
     vals[i] = (rand() % 1000);
+    std::cout << "origin key: " << keys[i] << " value:" << vals[i] << std::endl;
   }
 
   // push
@@ -41,6 +42,7 @@ void RunWorker() {
 
   float res = 0;
   for (int i = 0; i < num; ++i) {
+    std::cout << "pull key: " << keys[i] << " value:" << rets[i] << std::endl;
     res += fabs(rets[i] - vals[i] * repeat);
   }
   CHECK_LT(res / repeat, 1e-5);


### PR DESCRIPTION
@mli more understandable and get_sender_id will not be restricted to zmq_router. travis-ci error may be misleading.