### PR TITLE
Rename target libraray from libpslite.a to libps.a in cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ endif()
 list(APPEND SOURCE ${proto_srcs}) 
 add_library(pslite ${SOURCE}) 
 
+set_target_properties(pslite PROPERTIES OUTPUT_NAME "ps")
+
 target_link_libraries(pslite ${pslite_LINKER_LIBS})
 
 list(APPEND pslite_LINKER_LIBS_L_RELEASE ${Protobuf_LIBRARY})


### PR DESCRIPTION
Similar to https://github.com/dmlc/dmlc-core/pull/234 , target file names are inconsistent between `Makefile` and `CMakeLists.txt`, that is, `libps.a` and `libpslite.a` separately. Since `libps.a` is used in `mxnet` build, I think it is the expected one.

This commit renames the target libraray from `libpslite.a` to `libps.a` in cmake.