### PR TITLE
Fix bug in assign_op.h, Use not existed variables

### DIFF
--- a/include/ps/internal/assign_op.h
+++ b/include/ps/internal/assign_op.h
@@ -24,7 +24,7 @@ enum AssignOp {
  * \brief return an assignment function: right op= left
  */
 template<typename T>
-inline void AssignFunc(const T& lhs, AssignOp op, T* rhs) {
+inline void AssignFunc(const T& left, AssignOp op, T* right) {
   switch (op) {
     case ASSIGN:
       *right = left; break;
@@ -46,7 +46,7 @@ inline void AssignFunc(const T& lhs, AssignOp op, T* rhs) {
  * works for integers
  */
 template<typename T>
-inline void AssignFuncInt(const T& lhs, AssignOp op, T* rhs) {
+inline void AssignFuncInt(const T& left, AssignOp op, T* right) {
   switch (op) {
     case ASSIGN:
       *right = left; break;


### PR DESCRIPTION
Code in assign_op.h uses wrong variables. assign_op.h  is included in parallel_kv_match.h. But it seems that parallel_kv_match.h is not used.