### PR TITLE
[New Function]add reset function into kvstore_dist related stuffs.

### DIFF
--- a/include/ps/internal/message.h
+++ b/include/ps/internal/message.h
@@ -178,6 +178,8 @@ struct Meta {
   bool request;
   /** \brief whether or not a push message */
   bool push;
+  /** \brief whether or not a reset message */
+  bool reset;
   /** \brief whether or not it's for SimpleApp */
   bool simple_app;
   /** \brief an string body */


### PR DESCRIPTION
this will support reset kvstore-dist. it can be called by set_params in the python side.
aimed to reset the weights value of kvstore.
it is used to support the mxnet kvstore-dist functions. see https://github.com/dmlc/mxnet/pull/6435
@mli 