### PR TITLE
tests: fix a build error of test_kv_app

### DIFF
--- a/tests/test_kv_app.cc
+++ b/tests/test_kv_app.cc
@@ -1,4 +1,5 @@
 #include "ps/ps.h"
+#include "math.h"
 using namespace ps;
 
 void StartServer() {


### PR DESCRIPTION
Current master branch of ps-lite couldn't be built because of the
below error:

```
tests/test_kv_app.cc: In function 'void RunWorker()':
tests/test_kv_app.cc:44:43: error: 'fabs' was not declared in this scope
     res += fabs(rets[i] - vals[i] * repeat);
```

This commit fixes the problem by letting the file include math.h.