### PR TITLE
modify libprotobuf-lite.a to libprotobuf.a

### DIFF
--- a/make/ps.mk
+++ b/make/ps.mk
@@ -10,4 +10,4 @@ ADD_CFLAGS += -DUSE_KEY32=1
 endif
 
 PS_LDFLAGS_SO = -L$(DEPS_PATH)/lib -lprotobuf-lite -lzmq
-PS_LDFLAGS_A = $(addprefix $(DEPS_PATH)/lib/, libprotobuf-lite.a libzmq.a)
+PS_LDFLAGS_A = $(addprefix $(DEPS_PATH)/lib/, libprotobuf.a libzmq.a)


### PR DESCRIPTION
modify libprotobuf-lite.a to libprotobuf.a, used by https://github.com/apache/incubator-mxnet/pull/8437