### PR TITLE
Avoid listening on all interfaces by default

### DIFF
--- a/src/zmq_van.h
+++ b/src/zmq_van.h
@@ -63,7 +63,8 @@ class ZMQVan : public Van {
     CHECK(receiver_ != NULL)
         << "create receiver socket failed: " << zmq_strerror(errno);
     int local = GetEnv("DMLC_LOCAL", 0);
-    std::string addr = local ? "ipc:///tmp/" : "tcp://*:";
+    std::string hostname = node.hostname.empty() ? "*" : node.hostname;
+    std::string addr = local ? "ipc:///tmp/" : "tcp://" + hostname + ":";
     int port = node.port;
     unsigned seed = static_cast<unsigned>(time(NULL)+port);
     for (int i = 0; i < max_retry+1; ++i) {


### PR DESCRIPTION
This was identified by security review as a vulnerability.
With this change we only listen on the IP/interface that was either specified in configuration (`DMLC_PS_ROOT_URI` or `DMLC_INTERFACE`) or if no interface is specified in config, the non-loopback interface automatically picked by ps-lite.