### PR TITLE
bug fix: can't run on many nodes

### DIFF
--- a/src/resender.h
+++ b/src/resender.h
@@ -95,9 +95,9 @@ class Resender {
   uint64_t GetKey(const Message& msg) {
     CHECK_NE(msg.meta.timestamp, Meta::kEmpty) << msg.DebugString();
     uint16_t id = msg.meta.customer_id;
-    uint8_t sender = msg.meta.sender == Node::kEmpty ?
+    uint32_t sender = msg.meta.sender == Node::kEmpty ?
                      van_->my_node().id : msg.meta.sender;
-    uint8_t recver = msg.meta.recver;
+    uint32_t recver = msg.meta.recver;
     return (static_cast<uint64_t>(id) << 48) |
         (static_cast<uint64_t>(sender) << 40) |
         (static_cast<uint64_t>(recver) << 32) |


### PR DESCRIPTION
@mli @piiswrong Because `node_id` is of type `uint8`, when `node_id` is bigger than 256, some messages will be misjudged as duplicated so not sent appropriately.