### PR TITLE
RDMA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ git clone https://github.com/dmlc/ps-lite
 cd ps-lite && make -j4
 ```
 
+### Build with RDMA support
+
+You can add `USE_RDMA=1` to enable RDMA support.
+
+```bash
+make -j $(nproc) USE_RDMA=1
+```
+
 ### How to use
 
 `ps-lite` provides asynchronous communication for other projects: 

--- a/include/ps/internal/allocator.h
+++ b/include/ps/internal/allocator.h
@@ -1,0 +1,96 @@
+/**
+ *  Copyright (c) 2018 by Junxue Zhang, Jingrong Chen
+ */
+#ifndef PS_INTERNAL_ALLOCATOR_H_
+#define PS_INTERNAL_ALLOCATOR_H_
+#ifdef MXNET_USE_RDMA
+
+#include <rdma/rdma_cma.h>
+#include <memory>
+#include <unordered_map>
+#include <utility>
+#include "ps/internal/bfc_allocator.h"
+
+static const uint64_t kDefaultSize = 1ll * (1024 * 1024 * 1024);
+
+class Allocator {
+ public:
+  virtual void *Allocate(size_t size) { return nullptr; }
+  virtual void Deallocate(void *data) {}
+  virtual bool in_range(void *addr, size_t size) { return false; }
+  virtual void Register(void *addr, size_t size) {}
+};
+
+class DefaultAllocator : public Allocator {
+ public:
+  void *Allocate(size_t size) override { return reinterpret_cast<void *>(new char[size]); }
+  void Deallocate(void *data) override { delete[] reinterpret_cast<char *>(data); }
+};
+
+/**
+ * \breif NIC Allocator
+ */
+class NICAllocator : public Allocator {
+ public:
+  static NICAllocator *GetNICAllocator() {
+    static NICAllocator region_manager_;
+    return &region_manager_;
+  }
+
+  NICAllocator() {
+    ptr_ = malloc(kDefaultSize);
+    allocator_ = BFCAllocator::Create(1, kDefaultSize);
+  }
+
+  ~NICAllocator() {
+    free(ptr_);
+    allocator_ = nullptr;
+    for (const auto &e : addr_mr_) ibv_dereg_mr(e.second.first);
+  }
+
+  void *Allocate(size_t size) override {
+    if (size < 256) size = 256;
+    int64_t offset = allocator_->Allocate(size);
+    CHECK(offset != BFCAllocator::k_invalid_offset) << "apply for size: " << size;
+    return static_cast<void *>(static_cast<char *>(ptr_) + offset);
+  }
+
+  void Deallocate(void *data) override { allocator_->Deallocate(addr2offset(data)); }
+
+  inline bool registered(void *addr, size_t size) {
+    auto it = addr_mr_.find(addr);
+    return it != addr_mr_.end() && it->second.second >= size;
+  }
+
+  void Register(void *addr, size_t size) override {
+    addr_mr_[addr] = std::make_pair(ibv_reg_mr(pd_, addr, size, access_flag_), size);
+    CHECK(addr_mr_[addr].first) << "register region failed";
+  }
+
+  bool in_range(void *addr, size_t size) override {
+    uintptr_t a = (uintptr_t)addr;
+    uintptr_t l = (uintptr_t)ptr_;
+    return (l <= a && a + size <= l + kDefaultSize) || registered(addr, size);
+  }
+
+  void set_pd(struct ibv_pd *pd) { pd_ = pd; }
+
+  inline struct ibv_mr *mr(void *addr) { return addr_mr_[addr].first; }
+  inline void *ptr() const { return ptr_; }
+
+  void *ptr_;
+  std::shared_ptr<BFCAllocator> allocator_;
+  std::unordered_map<void *, std::pair<struct ibv_mr *, size_t>> addr_mr_;
+
+ private:
+  int64_t addr2offset(void *addr) {
+    CHECK(in_range(addr, 0)) << "address not in memory region";
+    return static_cast<int64_t>(static_cast<char *>(addr) - static_cast<char *>(ptr_));
+  }
+
+  struct ibv_pd *pd_;
+  static const int access_flag_ = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE;
+};
+
+#endif  // MXNET_USE_RDMA
+#endif  // PS_INTERNAL_ALLOCATOR_H_

--- a/include/ps/internal/bfc_allocator.h
+++ b/include/ps/internal/bfc_allocator.h
@@ -1,0 +1,207 @@
+/**
+ * Copyright 2017 Junxue Zhang
+ */
+#ifndef PS_INTERNAL_BFC_ALLOCATOR_H_
+#define PS_INTERNAL_BFC_ALLOCATOR_H_
+
+#include <cstdint>
+#include <cstdlib>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <vector>
+
+/**
+ * @brief The memory allocator
+ *
+ * The allocator is used to allocate offset (addresss from 0) from a given size of memory
+ * region
+ */
+class BFCAllocator : public std::enable_shared_from_this<BFCAllocator> {
+ public:
+  using Offset = int64_t;
+  using MemoryChunkId = int;
+
+  class MemoryChunk;
+  class MemoryBin;
+
+  static const size_t k_min_allocation_bits = 8;
+  static const size_t k_min_allocation_size = 1 << k_min_allocation_bits;
+
+  static const int k_num_of_bins = 21;
+  static const int k_invalid_bin_num = -1;
+
+  static const Offset k_invalid_offset = -1;
+
+  static const int k_invalid_chunk_id = -1;
+
+  using MemoryChunkPtr = std::shared_ptr<MemoryChunk>;
+
+  using MemoryBinPtr = std::shared_ptr<MemoryBin>;
+
+  /**
+   * @brief Constructor
+   *
+   * Need to call InitMemoryBins() and InitMemoryChunks() after calling constructor
+   *
+   * @param id the memroy allocator id
+   * @param size the size of managed memory region
+   */
+  BFCAllocator(int id, size_t size);
+
+  ~BFCAllocator();
+
+  /**
+   * @brief Initialize all memory bins
+   */
+  void InitMemoryBins();
+
+  /**
+   * @brief Initialize a memory chunk to hold all available space
+   */
+  void InitMemoryChunks();
+
+  /**
+   * @brief Create memory allocator and initilize memery bins and chunks
+   *
+   * It is a combination call of BFCAllocator(int id, size_t size), InitMemoryBins()
+   * and InitMemoryChunks()
+   *
+   * @param id the memroy allocator id
+   * @param size the size of buffer the allocator holds
+   *
+   * @return std::shared_ptr<BFCAllocator> the created memory allocator
+   */
+  static std::shared_ptr<BFCAllocator> Create(int id, size_t size);
+
+  /**
+   * @brief Allocate space from the managed memory region
+   *
+   * The allocated space is (offset, offset + size)
+   *
+   * @param size size of the allocation
+   *
+   * @return Offset offset
+   */
+  Offset Allocate(size_t size);
+
+  /**
+   * @brief Deallocate space
+   *
+   * @param offset the offset of the space to deallocate
+   */
+  void Deallocate(Offset offset);
+
+  /**
+   * @brief Get the avaiable size from the managed region
+   *
+   * The size of space may not be continous.
+   *
+   * @return size_t available size
+   */
+  size_t GetTotalAvaiableSize();
+
+  size_t RoundedBytes(size_t size);
+
+  int BinNumberFromSize(size_t size);
+  size_t SizeFromBinNumber(int bin_num);
+
+  Offset FindChunkOffset(int bin_num, size_t size);
+  void FreeAndMaybeCoalesce(MemoryChunkId id);
+
+  MemoryChunkId AllocateChunk();
+  MemoryChunkPtr GetChunk(MemoryChunkId id);
+  void DeleteChunk(MemoryChunkId id);
+  void DeallocateChunk(MemoryChunkId id);
+
+  void InsertFreeChunkIntoBin(MemoryChunkId id);
+  void RemoveFreeChunkFromBin(MemoryChunkId id);
+
+  void SplitChunk(MemoryChunkId id, size_t size);
+  void MergeChunk(MemoryChunkId id1, MemoryChunkId id2);
+
+  void ShowDebug();
+
+  /**
+   * @brief The memory chunk
+   */
+  class MemoryChunk {
+   public:
+    bool is_free;
+    Offset offset;
+    size_t size;
+
+    MemoryChunkId prev;
+    MemoryChunkId next;
+
+    int bin_num;
+  };
+
+  /**
+   * @brief The memory bin
+   */
+  class MemoryBin {
+   public:
+    MemoryBin(size_t size, std::weak_ptr<BFCAllocator> allocator)
+        : free_chunks(ChunkComparator(allocator)), size(size), parent_allocator(allocator) {}
+    MemoryChunkId FindChunkIdLargerThanSize(size_t rounded_size) {
+      auto allocator = parent_allocator.lock();
+      for (auto itr = std::begin(free_chunks); itr != std::end(free_chunks); ++itr) {
+        MemoryChunkId id = (*itr);
+        MemoryChunkPtr chunk = allocator->GetChunk(id);
+        if (chunk->size >= rounded_size) {
+          return id;
+        }
+      }
+      return k_invalid_chunk_id;
+    }
+    void InsertMemoryChunk(MemoryChunkId id) { free_chunks.insert(id); }
+    void RemoveMemoryChunk(MemoryChunkId id) { free_chunks.erase(id); }
+
+   private:
+    class ChunkComparator {
+     public:
+      explicit ChunkComparator(std::weak_ptr<BFCAllocator> allocator)
+          : parent_allocator(allocator) {}
+      bool operator()(const MemoryChunkId ha, const MemoryChunkId hb) const {
+        auto allocator = parent_allocator.lock();
+        const MemoryChunkPtr a = allocator->GetChunk(ha);
+        const MemoryChunkPtr b = allocator->GetChunk(hb);
+        if (a->size != b->size) {
+          return a->size < b->size;
+        }
+        return a->offset < b->offset;
+      }
+
+     private:
+      // The memory allocator
+      std::weak_ptr<BFCAllocator> parent_allocator;
+    };
+
+    using FreeChunkSet = std::set<MemoryChunkId, ChunkComparator>;
+    FreeChunkSet free_chunks;
+
+    size_t size;
+
+    std::weak_ptr<BFCAllocator> parent_allocator;
+  };
+
+ private:
+  int allocator_id;
+
+  std::vector<MemoryBinPtr> bins;
+
+  std::vector<MemoryChunkPtr> chunks;
+  std::map<Offset, MemoryChunkId> allocated_chunks;
+  MemoryChunkId free_chunks;
+
+  size_t total_allocated_size;
+  size_t total_size;
+
+  std::mutex mutex;
+
+  inline int Log2FloorNonZero(uint64_t n) { return 63 ^ __builtin_clzll(n); }
+};
+
+#endif  // PS_INTERNAL_BFC_ALLOCATOR_H_

--- a/include/ps/internal/message.h
+++ b/include/ps/internal/message.h
@@ -186,6 +186,8 @@ struct Meta {
   std::vector<DataType> data_type;
   /** \brief system control message */
   Control control;
+  /** \brief the byte size */
+  int data_size = 0;
 };
 /**
  * \brief messages that communicated amaong nodes.
@@ -202,7 +204,9 @@ struct Message {
   void AddData(const SArray<V>& val) {
     CHECK_EQ(data.size(), meta.data_type.size());
     meta.data_type.push_back(GetDataType<V>());
-    data.push_back(SArray<char>(val));
+    SArray<char> bytes(val);
+    meta.data_size += bytes.size();
+    data.push_back(bytes);
   }
   std::string DebugString() const {
     std::stringstream ss;

--- a/include/ps/internal/van.h
+++ b/include/ps/internal/van.h
@@ -15,6 +15,7 @@
 #include "ps/internal/message.h"
 namespace ps {
 class Resender;
+class PBMeta;
 /**
  * \brief Van sends messages to remote nodes
  *
@@ -91,6 +92,12 @@ class Van {
    * \return the number of bytes sent
    */
   virtual int SendMsg(const Message& msg) = 0;
+
+  /**
+   * \brief pack meta into protobuf
+   */
+  void PackMetaPB(const Meta& meta, PBMeta *pb);
+
   /**
    * \brief pack meta into a string
    */

--- a/include/ps/srmem.h
+++ b/include/ps/srmem.h
@@ -1,0 +1,282 @@
+/**
+ *  Copyright (c) 2018 by Jingrong Chen
+ */
+#ifndef PS_SRMEM_H_
+#define PS_SRMEM_H_
+#ifdef MXNET_USE_RDMA
+#include <string.h>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+#include "ps/internal/bfc_allocator.h"
+#include "ps/internal/allocator.h"
+#include "ps/internal/utils.h"
+#include "ps/range.h"
+namespace ps {
+
+template <typename V>
+class SArray;
+
+inline Allocator *GetAllocator() {
+  return NICAllocator::GetNICAllocator();
+}
+
+/**
+ * \breif Shared RDMA Memory region
+ *
+ * A memory region registered by RDMA use that managed by shared pointer.
+ * It is designed to help implement zero-copy RDMA operation.
+ * It retains the element type and provides basic functionalities to access
+ * these elements. SRMem can be constructed from SArray and c-array,
+ * for instances
+ *
+ * \code
+ * SArray<float> sa(10); SRMem<float> sr(sa); // copying
+ * \endcode
+ *
+ * \code
+ * char *c = malloc(10);
+ * SRMem<int> sr(c, 10);
+ * \endcode
+ *
+ * \tparam V the value type
+ */
+template <typename V>
+class SRMem {
+ public:
+  /** \brief empty constructor */
+  SRMem() {}
+
+  /** \brief empty deconstrcutor */
+  ~SRMem() {}
+
+  /**
+   * \brief Create an array with length n with initialized value
+   * \param size the length
+   * \param val the initial length (0 in default)
+   */
+  explicit SRMem(size_t size, V val = 0) { resize(size, val); }
+
+  /**
+   * \brief Constructor from a SArray
+   *
+   * Simply copy the data
+   *
+   * \param arr the source array
+   */
+  explicit SRMem(const SArray<V>& arr) {
+    /* when the copy cost is less than doing ibv_reg_mr, copy it */
+    if (arr.size() >= 16384 && !GetAllocator()->in_range(arr.data(), arr.size())) {
+      GetAllocator()->Register(arr.data(), arr.size());
+    }
+    if (arr.size() >= 16384) {
+      reset(arr.data(), arr.size(), [](V* data) {});
+    } else {
+      CopyFrom(arr.data(), arr.size());
+    }
+  }
+
+  /**
+   * \brief Requests that the capacity be at least enough to contain n elements.
+   *
+   * Zero-copy constructor, namely just copy the pointer
+   *
+   * \tparam W the value type of the source array
+   * \param arr the source array
+   */
+  template <typename W>
+  explicit SRMem(const SRMem<W>& arr) {
+    *this = arr;
+  }
+
+  /**
+   * \brief construct from another SRMem.
+   *
+   * Zero-copy constructor, namely just copy the pointer
+   *
+   * \tparam W the value type of the source array
+   * \param arr the source array
+   */
+  template <typename W>
+  void operator=(const SRMem<W>& arr) {
+    size_ = arr.size() * sizeof(W) / sizeof(V);
+    CHECK_EQ(size_ * sizeof(V), arr.size() * sizeof(W)) << "cannot be divided";
+    capacity_ = arr.capacity() * sizeof(W) / sizeof(V);
+
+    CHECK(GetAllocator()->in_range(arr.data(), arr.size())) << "SRMem not in range";
+    ptr_ = std::shared_ptr<V>(arr.ptr(), reinterpret_cast<V*>(arr.data()));
+  }
+
+  /**
+   * \brief construct from a c-array
+   *
+   * Just copy the pointer if the buffer is registered by RDMA
+   * Copy the data otherwise
+   *
+   * \param data the source data
+   * \param size the length
+   * \param deletable whether or not can call `NICAllocator::GetNICAllocator()->Deallocate(data)`
+   * when the reference count goes 0
+   */
+
+  SRMem(V* data, size_t size, bool deletable = false) {
+    if (deletable) {
+      /* TODO(cjr) here we may do one more copy */
+      if (GetAllocator()->in_range(data, size)) {
+        reset(data, size, [this](V* data) { GetAllocator()->Deallocate(data); });
+      } else {
+        V* new_data = reinterpret_cast<V*>(GetAllocator()->Allocate(size * sizeof(V)));
+        memcpy(new_data, data, size * sizeof(V));
+        reset(new_data, size, [this](V* data) { GetAllocator()->Deallocate(data); });
+      }
+    } else {
+      if (GetAllocator()->in_range(data, size)) {
+        reset(data, size, [this](V* data) {});
+      } else {
+        V* new_data = reinterpret_cast<V*>(GetAllocator()->Allocate(size * sizeof(V)));
+        memcpy(new_data, data, size * sizeof(V));
+        reset(new_data, size, [](V* data) {});
+      }
+    }
+  }
+
+  /**
+   * \brief copy from a c-array
+   *
+   * \param data the source data
+   * \param size the length
+   */
+  void CopyFrom(const V* data, size_t size) {
+    resize(size);
+    memcpy(this->data(), data, size * sizeof(V));
+  }
+
+  /**
+   * \brief copy from another SRMem
+   *
+   * \param other the source data
+   */
+  void CopyFrom(const SRMem<V>& other) {
+    if (this == &other) return;
+    CopyFrom(other.data(), other.size());
+  }
+
+  /**
+   * \brief copy from an iterator
+   */
+  template <typename ForwardIt>
+  void CopyFrom(const ForwardIt& first, const ForwardIt& last) {
+    int size = static_cast<int>(std::distance(first, last));
+    V* data = reinterpret_cast<V*>(GetAllocator()->Allocate(size * sizeof(V)));
+    reset(data, size, [this](V* data) { GetAllocator()->Deallocate(data); });
+    for (auto it = first; it < last; ++it) *data++ = *it;
+  }
+
+  /**
+   * @brief Reset the current data pointer with a deleter
+   */
+  template <typename Deleter>
+  void reset(V* data, size_t size, Deleter del) {
+    size_ = size;
+    capacity_ = size;
+    ptr_.reset(data, del);
+  }
+
+  /**
+   * @brief Resizes the array to size elements
+   *
+   * If size <= capacity_, then only change the size. otherwise, append size -
+   * current_size entries, and then set new value to val
+   */
+  void resize(size_t size, V val = 0) {
+    size_t cur_n = size_;
+    if (capacity_ >= size) {
+      size_ = size;
+    } else {
+      /* TODO(cjr) FIXME(cjr) when size * sizeof(V) >= REGION_SIZE*/
+      V* new_data = reinterpret_cast<V*>(GetAllocator()->Allocate((size + 5) * sizeof(V)));
+      memcpy(new_data, data(), size_ * sizeof(V));
+      reset(new_data, size, [this](V* data) { GetAllocator()->Deallocate(data); });
+    }
+    if (size <= cur_n) return;
+    V* p = data() + cur_n;
+    if (val == 0) {
+      memset(p, 0, (size - cur_n) * sizeof(V));
+    } else {
+      for (; cur_n < size; cur_n++) *p++ = val;
+    }
+  }
+
+  /**
+   * @brief Requests that the capacity be at least enough to contain n elements.
+   */
+  void reserve(size_t size) {
+    if (capacity_ >= size) {
+      return;
+    }
+    size_t old_size = size_;
+    resize(size);
+    size_ = old_size;
+  }
+
+  /** @brief release the memory */
+  void clear() {
+    reset(nullptr, 0, [](V* data) {});
+  }
+
+  inline bool empty() const { return size() == 0; }
+  inline size_t size() const { return size_; }
+  inline size_t capacity() const { return capacity_; }
+  inline size_t bytesize() const { return size_ * sizeof(V); }
+
+  inline V* begin() { return data(); }
+  inline const V* begin() const { return data(); }
+  inline V* end() { return data() + size(); }
+  inline const V* end() const { return data() + size(); }
+
+  inline V* data() const { return ptr_.get(); }
+
+  /** \brief get the shared pointer */
+  inline std::shared_ptr<V>& ptr() { return ptr_; }
+  /** \brief get the const shared pointer */
+  inline const std::shared_ptr<V>& ptr() const { return ptr_; }
+
+  inline V back() const {
+    CHECK(!empty());
+    return data()[size_ - 1];
+  }
+  inline V front() const {
+    CHECK(!empty());
+    return data()[0];
+  }
+  inline V& operator[](int i) { return data()[i]; }
+  inline const V& operator[](int i) const { return data()[i]; }
+
+  inline void push_back(const V& val) {
+    if (size_ == capacity_) reserve(size_ * 2 + 5);
+    data()[size_++] = val;
+  }
+
+  void pop_back() {
+    if (size_) --size_;
+  }
+
+ private:
+  size_t size_ = 0;
+  size_t capacity_ = 0;
+  std::shared_ptr<V> ptr_;
+};
+
+/**
+ * \brief print a debug string
+ */
+template <typename V>
+std::ostream& operator<<(std::ostream& os, const SRMem<V>& obj) {
+  os << DebugStr(obj.data(), obj.size());
+  return os;
+}
+
+}  // namespace ps
+#endif  // MXNET_USE_RDMA
+#endif  // PS_SRMEM_H_

--- a/src/bfc_allocator.cc
+++ b/src/bfc_allocator.cc
@@ -1,0 +1,243 @@
+/**
+ * Copyright 2017 Junxue Zhang, Jingrong Chen
+ */
+#include "ps/internal/bfc_allocator.h"
+
+#include <cassert>
+#include <iostream>
+
+// Implementation of BFCAllocator
+
+BFCAllocator::BFCAllocator(int id, size_t size)
+    : allocator_id(id),
+      bins(k_num_of_bins),
+      free_chunks(k_invalid_chunk_id),
+      total_allocated_size(0) {
+  total_size = RoundedBytes(size);
+}
+
+BFCAllocator::~BFCAllocator() {}
+
+void BFCAllocator::InitMemoryBins() {
+  for (auto bin_num = 0; bin_num < k_num_of_bins; ++bin_num) {
+    size_t bin_size = SizeFromBinNumber(bin_num);
+    MemoryBinPtr bin = std::make_shared<MemoryBin>(bin_size, shared_from_this());
+    bins[bin_num] = bin;
+  }
+}
+
+void BFCAllocator::InitMemoryChunks() {
+  MemoryChunkId chunk_id = AllocateChunk();
+  MemoryChunkPtr chunk = GetChunk(chunk_id);
+  chunk->is_free = true;
+  chunk->offset = 0;
+  chunk->size = total_size;
+  chunk->prev = k_invalid_chunk_id;
+  chunk->next = k_invalid_chunk_id;
+  chunk->bin_num = k_invalid_bin_num;
+
+  InsertFreeChunkIntoBin(chunk_id);
+  allocated_chunks[chunk->offset] = chunk_id;
+}
+
+std::shared_ptr<BFCAllocator> BFCAllocator::Create(int id, size_t size) {
+  std::shared_ptr<BFCAllocator> allocator = std::make_shared<BFCAllocator>(id, size);
+  allocator->InitMemoryBins();
+  allocator->InitMemoryChunks();
+  return allocator;
+}
+
+BFCAllocator::Offset BFCAllocator::Allocate(size_t size) {
+  if (size == 0) {
+    return k_invalid_offset;
+  }
+
+  size_t rounded_size = RoundedBytes(size);
+  int bin_num = BinNumberFromSize(rounded_size);
+
+  std::lock_guard<std::mutex> lock(mutex);
+
+  Offset offset = FindChunkOffset(bin_num, rounded_size);
+  return offset;
+}
+
+void BFCAllocator::Deallocate(Offset offset) {
+  if (offset == k_invalid_offset) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex);
+  auto itr = allocated_chunks.find(offset);
+  if (itr == std::end(allocated_chunks)) {
+    assert(0);
+    return;
+  }
+  MemoryChunkId chunk_id = itr->second;
+  FreeAndMaybeCoalesce(chunk_id);
+}
+
+size_t BFCAllocator::GetTotalAvaiableSize() { return total_size - total_allocated_size; }
+
+size_t BFCAllocator::RoundedBytes(size_t bytes) {
+  size_t rounded_bytes =
+      (k_min_allocation_size * ((bytes + k_min_allocation_size - 1) / k_min_allocation_size));
+  return rounded_bytes;
+}
+
+int BFCAllocator::BinNumberFromSize(size_t size) {
+  uint64_t v = std::max<size_t>(size, 256) >> k_min_allocation_bits;
+  int b = std::min(k_num_of_bins - 1, Log2FloorNonZero(v));
+  return b;
+}
+
+size_t BFCAllocator::SizeFromBinNumber(int bin_num) { return static_cast<size_t>(256) << bin_num; }
+
+BFCAllocator::Offset BFCAllocator::FindChunkOffset(int bin_num, size_t rounded_size) {
+  for (; bin_num < k_num_of_bins; bin_num++) {
+    MemoryBinPtr bin = bins[bin_num];
+    MemoryChunkId chunk_id = bin->FindChunkIdLargerThanSize(rounded_size);
+
+    if (chunk_id == k_invalid_chunk_id) continue;
+    MemoryChunkPtr chunk = GetChunk(chunk_id);
+    assert(chunk->is_free == true);
+
+    bin->RemoveMemoryChunk(chunk_id);
+    chunk->bin_num = k_invalid_bin_num;
+    if (chunk->size >= rounded_size * 2) {
+      SplitChunk(chunk_id, rounded_size);
+    }
+    chunk->is_free = false;
+    total_allocated_size += rounded_size;
+    return chunk->offset;
+  }
+  return k_invalid_offset;
+}
+
+void BFCAllocator::FreeAndMaybeCoalesce(MemoryChunkId id) {
+  MemoryChunkPtr chunk = GetChunk(id);
+  assert(chunk->is_free == false && chunk->bin_num == k_invalid_bin_num);
+
+  chunk->is_free = true;
+
+  MemoryChunkId chunk_to_insert_back = id;
+
+  if (chunk->next != k_invalid_chunk_id) {
+    MemoryChunkPtr next_chunk = GetChunk(chunk->next);
+    if (next_chunk->is_free) {
+      chunk_to_insert_back = id;
+      RemoveFreeChunkFromBin(chunk->next);
+      MergeChunk(id, chunk->next);
+    }
+  }
+
+  if (chunk->prev != k_invalid_chunk_id) {
+    MemoryChunkPtr prev_chunk = GetChunk(chunk->prev);
+    if (prev_chunk->is_free) {
+      chunk_to_insert_back = chunk->prev;
+      RemoveFreeChunkFromBin(chunk->prev);
+      MergeChunk(chunk->prev, id);
+    }
+  }
+  InsertFreeChunkIntoBin(chunk_to_insert_back);
+}
+
+BFCAllocator::MemoryChunkId BFCAllocator::AllocateChunk() {
+  if (free_chunks == k_invalid_chunk_id) {
+    MemoryChunkPtr chunk = std::make_shared<MemoryChunk>();
+    chunks.push_back(chunk);
+    return chunks.size() - 1;
+  } else {
+    MemoryChunkId id = free_chunks;
+    MemoryChunkPtr chunk = GetChunk(id);
+    free_chunks = chunk->next;
+    return id;
+  }
+}
+
+BFCAllocator::MemoryChunkPtr BFCAllocator::GetChunk(MemoryChunkId id) { return chunks[id]; }
+
+void BFCAllocator::DeleteChunk(MemoryChunkId id) {
+  MemoryChunkPtr chunk = GetChunk(id);
+  allocated_chunks.erase(chunk->offset);
+  DeallocateChunk(id);
+}
+
+void BFCAllocator::DeallocateChunk(MemoryChunkId id) {
+  MemoryChunkPtr chunk = GetChunk(id);
+  chunk->next = free_chunks;
+  free_chunks = id;
+}
+
+void BFCAllocator::InsertFreeChunkIntoBin(MemoryChunkId id) {
+  MemoryChunkPtr chunk = GetChunk(id);
+  assert(chunk->is_free == true && chunk->bin_num == k_invalid_bin_num);
+  int bin_num = BinNumberFromSize(chunk->size);
+  MemoryBinPtr bin = bins[bin_num];
+  chunk->bin_num = bin_num;
+  bin->InsertMemoryChunk(id);
+}
+
+void BFCAllocator::RemoveFreeChunkFromBin(MemoryChunkId id) {
+  MemoryChunkPtr chunk = GetChunk(id);
+  assert(chunk->is_free == true && chunk->bin_num != k_invalid_bin_num);
+  MemoryBinPtr bin = bins[chunk->bin_num];
+  bin->RemoveMemoryChunk(id);
+  chunk->bin_num = k_invalid_bin_num;
+}
+
+void BFCAllocator::SplitChunk(MemoryChunkId id, size_t size) {
+  MemoryChunkPtr chunk = GetChunk(id);
+  assert(chunk->is_free == true && chunk->bin_num == k_invalid_bin_num);
+
+  MemoryChunkId new_chunk_id = AllocateChunk();
+  MemoryChunkPtr new_chunk = GetChunk(new_chunk_id);
+  new_chunk->offset = chunk->offset + size;
+  new_chunk->size = chunk->size - size;
+  chunk->size = size;
+  new_chunk->is_free = true;
+  new_chunk->bin_num = k_invalid_bin_num;
+
+  allocated_chunks[new_chunk->offset] = new_chunk_id;
+
+  MemoryChunkId chunk_neighbor_id = chunk->next;
+  chunk->next = new_chunk_id;
+  new_chunk->next = chunk_neighbor_id;
+  new_chunk->prev = id;
+  if (chunk_neighbor_id != k_invalid_chunk_id) {
+    MemoryChunkPtr chunk_neighbor = GetChunk(chunk_neighbor_id);
+    chunk_neighbor->prev = new_chunk_id;
+  }
+  InsertFreeChunkIntoBin(new_chunk_id);
+}
+
+void BFCAllocator::MergeChunk(MemoryChunkId id1, MemoryChunkId id2) {
+  MemoryChunkPtr chunk1 = GetChunk(id1);
+  MemoryChunkPtr chunk2 = GetChunk(id2);
+
+  assert(chunk1->is_free && chunk2->is_free);
+
+  MemoryChunkId id3 = chunk2->next;
+  chunk1->next = id3;
+  if (id3 != k_invalid_chunk_id) {
+    MemoryChunkPtr chunk3 = GetChunk(id3);
+    chunk3->prev = id1;
+  }
+  chunk1->size += chunk2->size;
+
+  DeleteChunk(id2);
+}
+
+void BFCAllocator::ShowDebug() {
+  std::cout << "Showing debug info for allocator: " << allocator_id << std::endl;
+  for (size_t i = 0; i < chunks.size(); ++i) {
+    MemoryChunkPtr ptr = chunks[i];
+    std::cout << "Memory Chunk: " << i << " ["
+              << "is_free: " << ptr->is_free << "\t"
+              << "offset: " << ptr->offset << "\t"
+              << "size: " << ptr->size << "\t"
+              << "bin_num: " << ptr->bin_num << "\t"
+              << "prev: " << ptr->prev << "\t"
+              << "next: " << ptr->next << "\t"
+              << "]" << std::endl;
+  }
+}

--- a/src/meta.proto
+++ b/src/meta.proto
@@ -46,4 +46,6 @@ message PBMeta {
   optional bool push = 5;
   // whether or not it's for SimpleApp
   optional bool simple_app = 6 [default = false];
+  // message.data_size 
+  optional int32 data_size = 11;
 }

--- a/src/postoffice.cc
+++ b/src/postoffice.cc
@@ -10,9 +10,15 @@
 
 namespace ps {
 Postoffice::Postoffice() {
-  van_ = Van::Create("zmq");
   env_ref_ = Environment::_GetSharedRef();
   const char* val = NULL;
+  int enable_rdma = GetEnv("DMLC_ENABLE_RDMA", 0);
+  if (enable_rdma) {
+    LOG(INFO) << "enable RDMA for networking";
+    van_ = Van::Create("rdma");
+  } else {
+    van_ = Van::Create("zmq");
+  }
   val = CHECK_NOTNULL(Environment::Get()->find("DMLC_NUM_WORKER"));
   num_workers_ = atoi(val);
   val =  CHECK_NOTNULL(Environment::Get()->find("DMLC_NUM_SERVER"));

--- a/src/rdma_van.h
+++ b/src/rdma_van.h
@@ -1,0 +1,649 @@
+/**
+ *  Copyright (c) 2017 by Junxue ZHANG, Jingrong CHEN
+ */
+#ifndef PS_RDMA_VAN_H_
+#define PS_RDMA_VAN_H_
+#ifdef MXNET_USE_RDMA
+
+#include <errno.h>
+#include <netdb.h>
+#include <stdlib.h>
+
+#include <rdma/rdma_cma.h>
+
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "ps/internal/allocator.h"
+#include "ps/internal/bfc_allocator.h"
+#include "ps/internal/threadsafe_queue.h"
+#include "ps/internal/van.h"
+#include "ps/srmem.h"
+
+namespace ps {
+
+const int kRxDepth = 500;
+const int kTxDepth = 500;
+const int kSGEntry = 5;
+const int kTimeoutms = 1000;
+
+enum rdma_msg_type {
+  MSG_REQ_REGION,
+  MSG_RES_REGION,
+  MSG_WRITE_DONE,
+};
+
+/*
+ * RDMA maximum message size <= 2GB,
+ * thus we use 32bit int when it comes to length and offset
+ */
+
+struct rdma_write_header {
+  int sender;
+  int recver;
+  int length[5];
+};
+
+struct rdma_msg {
+  rdma_msg_type type;
+  union {
+    /* MSG_REQ_REGION */
+    int length[5];
+    struct {
+      /* MSG_RES_REGION */
+      struct {
+        void *addr[5];
+        uint32_t rkey;
+      } mr;
+      /* MSG_WRITE_DONE */
+      struct rdma_write_header header;
+    };
+  } data;
+};
+
+struct context {
+  struct ibv_context *ctx;
+  struct ibv_pd *pd;
+  struct ibv_cq *cq;
+  struct ibv_mr *rdma_mr;
+  int cnt;
+};
+
+struct connection {
+  struct rdma_cm_id *id;
+  struct ibv_qp *qp;
+  struct ibv_cq *cq;
+
+  int sr_slots, rr_slots;
+
+  struct rdma_msg *send_msg;
+  struct rdma_msg *recv_msg;
+  struct ibv_mr *send_msg_mr;
+  struct ibv_mr *recv_msg_mr;
+
+  volatile int connected;
+  int active_side;
+};
+
+class RDMAVan : public Van {
+ public:
+  RDMAVan() {}
+  ~RDMAVan() {}
+
+ protected:
+  void Start() override {
+    event_channel_ = rdma_create_event_channel();
+    CHECK(event_channel_) << "create RDMA event channel failed";
+    event_poller_should_stop_ = false;
+    rdma_cm_event_poller_thread_ = new std::thread(&RDMAVan::OnEvent, this);
+    Van::Start();
+  }
+
+  void Stop() override {
+    PS_VLOG(1) << my_node_.ShortDebugString() << " is stopping";
+    Van::Stop();
+
+    rdma_destroy_id(listener_);
+
+    cq_poller_should_stop_ = true;
+    cq_poller_thread_->join();
+    delete cq_poller_thread_;
+
+    for (auto it : connections_) rdma_disconnect(it.second);
+
+    /* FIXME(cjr) how do we know the OnDisconnected is done? */
+    event_poller_should_stop_ = true;
+    rdma_cm_event_poller_thread_->join();
+    delete rdma_cm_event_poller_thread_;
+
+    rdma_destroy_event_channel(event_channel_);
+
+    ibv_destroy_cq(context_->cq);
+    ibv_dereg_mr(context_->rdma_mr);
+    free(context_);
+  }
+
+  int Bind(const Node &node, int max_retry) override {
+    CHECK(rdma_create_id(event_channel_, &listener_, nullptr, RDMA_PS_TCP) == 0)
+        << "create RDMA connection identifier failed";
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    int port = node.port;
+
+    for (int i = 0; i < max_retry + 1; ++i) {
+      addr.sin_port = htons(port);
+      if (rdma_bind_addr(listener_, (struct sockaddr *)&addr) == 0) break;
+
+      if (i == max_retry)
+        port = -1;
+      else
+        port += 1;
+    }
+    CHECK(rdma_listen(listener_, 10) == 0) << "listen RDMA connection failed";
+
+    return port;
+  }
+
+  void Connect(const Node &node) override {
+    CHECK_NE(node.id, node.kEmpty);
+    CHECK_NE(node.port, node.kEmpty);
+    CHECK(node.hostname.size());
+    int node_id = node.id;
+
+    if ((node.role == my_node_.role) && (node.id != my_node_.id)) return;
+
+    struct rdma_cm_id *id;
+    CHECK(rdma_create_id(event_channel_, &id, nullptr, RDMA_PS_TCP) == 0)
+        << "create RDMA connection identifier failed";
+    InitConnection(id, true);
+
+    struct addrinfo *addr;
+    CHECK(getaddrinfo(node.hostname.c_str(), std::to_string(node.port).c_str(), nullptr, &addr) ==
+          0)
+        << "set address and port for connection failed";
+
+    CHECK(rdma_resolve_addr(id, nullptr, addr->ai_addr, kTimeoutms) == 0)
+        << "resolve RDMA address failed with errno: " << errno;
+
+    freeaddrinfo(addr);
+
+    struct connection *conn = (struct connection *)id->context;
+    while (!IsConnected(conn)) {
+    }
+
+    connections_[node_id] = id;
+    LOG(INFO) << "Connected to node: " << node_id;
+  }
+
+  void make_sge(struct ibv_sge *sge, void *addr, uint32_t length, uint32_t lkey) {
+    sge->addr = (uintptr_t)addr;
+    sge->length = length;
+    sge->lkey = lkey;
+  }
+
+  void WriteToPeer(struct connection *conn, int recver, const SRMem<char> &srmem, void *addr,
+                   uint32_t rkey, uint32_t lkey) {
+    struct ibv_sge sge;
+    struct ibv_send_wr wr, *bad_wr = nullptr;
+
+    memset(&wr, 0, sizeof(wr));
+
+    // wr.wr_id = (uintptr_t)conn;
+    wr.opcode = IBV_WR_RDMA_WRITE;
+    wr.next = nullptr;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.wr.rdma.remote_addr = (uintptr_t)addr;
+    wr.wr.rdma.rkey = rkey;
+    wr.send_flags = IBV_SEND_SIGNALED;
+
+    make_sge(&sge, srmem.data(), srmem.size(), lkey);
+
+    /* Post Write Request */
+    while (conn->sr_slots >= kTxDepth - 1) {
+    }
+    conn->sr_slots++;
+    CHECK(ibv_post_send(conn->qp, &wr, &bad_wr) == 0)
+        << "RDMA post send failed with errno: " << errno;
+
+    /* Poll RDMA_WRITE Completion */
+    int ret;
+    struct ibv_wc wc;
+    do {
+      while ((ret = ibv_poll_cq(conn->cq, 1, &wc)) == 0) {
+      }
+      CHECK_GE(ret, 0);
+      CHECK(wc.status == IBV_WC_SUCCESS) << "poll cq failed: " << wc.status;
+      if (wc.opcode == IBV_WC_RECV) {
+        if (--conn->rr_slots <= 1) {
+          PostRecvRDMAMsg(conn, kRxDepth - conn->rr_slots);
+          conn->rr_slots = kRxDepth;
+        }
+      }
+    } while (wc.opcode != IBV_WC_RDMA_WRITE);
+    CHECK(wc.opcode == IBV_WC_RDMA_WRITE) << "opcode != IBV_WC_RDMA_WRITE" << wc.opcode;
+
+    conn->sr_slots--;
+  }
+
+  int SendMsg(const Message &msg) override {
+    /* TODO(zjx) do we really need mutex lock */
+    std::lock_guard<std::mutex> lock(s_send_mutex_);
+
+    /* find the connection end point */
+    int recver_id = msg.meta.recver;
+    CHECK_NE(recver_id, Meta::kEmpty);
+
+    auto it = connections_.find(recver_id);
+    if (it == connections_.end()) {
+      LOG(WARNING) << "there is no socket to node: " << recver_id;
+      return -1;
+    }
+
+    struct rdma_cm_id *rdma_id = it->second;
+    struct connection *conn = (struct connection *)rdma_id->context;
+
+    PBMeta meta;
+    PackMetaPB(msg.meta, &meta);
+    uint32_t meta_size = meta.ByteSize();
+    size_t send_bytes = meta_size + msg.meta.data_size;
+
+    /* 1. Send region request */
+    conn->send_msg->type = MSG_REQ_REGION;
+    conn->send_msg->data.length[0] = meta_size;
+    for (size_t i = 0; i < msg.data.size(); i++)
+      conn->send_msg->data.length[i + 1] = msg.data[i].size();
+    conn->send_msg->data.length[msg.data.size() + 1] = -1;
+    PostSendRDMAMsg(conn);
+
+    /* 2. Busy polling region response */
+    struct ibv_wc wc;
+    PollRDMAMsg(conn->cq, &wc);
+
+    CHECK(conn->recv_msg->type == MSG_RES_REGION)
+        << "receive message type != MSG_RES_REGION, " << conn->recv_msg->type;
+    conn->sr_slots--;
+
+    /* 3. Send the data using RDMA_WRITE */
+
+    /* Fill the RDMA header */
+    struct rdma_write_header *header;
+    header = &conn->send_msg->data.header;
+    header->sender = my_node_.id;
+    header->recver = recver_id;
+    header->length[0] = meta_size;
+
+    SRMem<char> srmem(meta_size);
+    meta.SerializeToArray(srmem.data(), meta_size);
+    WriteToPeer(conn, recver_id, srmem, conn->recv_msg->data.mr.addr[0],
+                conn->recv_msg->data.mr.rkey, context_->rdma_mr->lkey);
+
+    for (size_t i = 0; i < msg.data.size(); i++) {
+      /* This should be tune further */
+      SRMem<char> srmem(msg.data[i]);
+      uint32_t lkey = context_->rdma_mr->lkey;
+      if (NICAllocator::GetNICAllocator()->registered(srmem.data(), 0))
+        lkey = NICAllocator::GetNICAllocator()->mr(srmem.data())->lkey;
+      WriteToPeer(conn, recver_id, srmem, conn->recv_msg->data.mr.addr[i + 1],
+                  conn->recv_msg->data.mr.rkey, lkey);
+
+      header->length[i + 1] = msg.data[i].size();
+    }
+    header->length[msg.data.size() + 1] = -1;
+
+    /* 4. Notify remote side WRITE_DONE */
+    conn->send_msg->type = MSG_WRITE_DONE;
+    conn->send_msg->data.mr = conn->recv_msg->data.mr;
+    PostSendRDMAMsg(conn);
+
+    /* 5. Receive ACK_WRITE_DONE */
+    do {
+      int ret;
+      while ((ret = ibv_poll_cq(conn->cq, 1, &wc)) == 0) {
+      }
+      CHECK_GE(ret, 0);
+      CHECK(wc.status == IBV_WC_SUCCESS) << "poll cq failed: " << wc.status;
+      if (wc.opcode == IBV_WC_RECV) {
+        if (--conn->rr_slots <= 1) {
+          PostRecvRDMAMsg(conn, kRxDepth - conn->rr_slots);
+          conn->rr_slots = kRxDepth;
+        }
+        if (conn->recv_msg->type == MSG_WRITE_DONE) break;
+      }
+    } while (1);
+
+    CHECK(conn->recv_msg->type == MSG_WRITE_DONE)
+        << "type != WRITE_DONE, bug" << conn->recv_msg->type;
+
+    conn->sr_slots--;
+
+    return send_bytes;
+  }
+
+  void PollCQ() {
+    struct connection *conn;
+    struct ibv_wc wc;
+
+    while (!cq_poller_should_stop_) {
+      int ret = ibv_poll_cq(context_->cq, 1, &wc);
+      CHECK(ret >= 0) << "error happens in ibv_poll_cq";
+
+      if (ret == 0) continue;
+      CHECK(wc.status == IBV_WC_SUCCESS)
+          << "the worker completion status is not ibv_wc_success, but " << wc.status;
+
+      conn = (struct connection *)wc.wr_id;
+
+      if (wc.opcode == IBV_WC_RECV) {
+        if (--conn->rr_slots <= 1) {
+          PostRecvRDMAMsg(conn, kRxDepth - conn->rr_slots);
+          conn->rr_slots = kRxDepth;
+        }
+      }
+      if (wc.opcode == IBV_WC_SEND) {
+        conn->sr_slots--;
+        continue;
+      }
+
+      if (conn->recv_msg->type == MSG_REQ_REGION) {
+        /* 1. Response MSG_REQ_REGION */
+        conn->send_msg->type = MSG_RES_REGION;
+        auto &data = conn->recv_msg->data;
+
+        for (int i = 0, length; (length = data.length[i]) != -1; i++) {
+          if (length == 0) length = 256;
+          conn->send_msg->data.mr.addr[i] = NICAllocator::GetNICAllocator()->Allocate(length);
+        }
+        conn->send_msg->data.mr.rkey = context_->rdma_mr->rkey;
+        PostSendRDMAMsg(conn, IBV_SEND_SIGNALED);
+
+      } else if (conn->recv_msg->type == MSG_WRITE_DONE) {
+        write_done_queue_.Push(*conn->recv_msg);
+        conn->send_msg->type = MSG_WRITE_DONE;
+        PostSendRDMAMsg(conn, IBV_SEND_SIGNALED);
+      } else {
+        LOG(ERROR) << "Unexpected msg: " << conn->recv_msg->type;
+        exit(-1);
+      }
+    }
+  }
+
+  int RecvMsg(Message *msg) override {
+    size_t recv_bytes = 0;
+    struct rdma_write_header *header;
+    struct rdma_msg recv_msg;
+
+    msg->data.clear();
+
+    void *addr;
+
+    write_done_queue_.WaitAndPop(&recv_msg);
+
+    /* handle message meta */
+    addr = recv_msg.data.mr.addr[0];
+
+    header = &recv_msg.data.header;
+    msg->meta.sender = header->sender;
+    msg->meta.recver = my_node_.id;
+
+    UnpackMeta(static_cast<char *>(addr), header->length[0], &msg->meta);
+    NICAllocator::GetNICAllocator()->Deallocate(addr);
+
+    recv_bytes += header->length[0];
+
+    // Zero-copy receiving
+    for (int i = 1; header->length[i] != -1; i++) {
+      addr = recv_msg.data.mr.addr[i];
+      SRMem<char> srmem(static_cast<char *>(addr), header->length[i], true);
+      SArray<char> sarray(srmem);
+      msg->data.push_back(sarray);
+
+      recv_bytes += header->length[i];
+    }
+
+    return recv_bytes;
+  }
+
+ private:
+  bool IsConnected(struct connection *conn) { return conn->connected == 1; }
+
+  void InitConnection(struct rdma_cm_id *id, bool active_side) {
+    struct connection *conn = (struct connection *)malloc(sizeof(struct connection));
+    id->context = conn;
+    conn->id = id;
+    conn->connected = 0;
+    conn->active_side = active_side;
+  }
+
+  void OnEvent() {
+    struct rdma_cm_event *event;
+
+    while (!event_poller_should_stop_ && rdma_get_cm_event(event_channel_, &event) == 0) {
+      struct rdma_cm_event event_copy;
+      memcpy(&event_copy, event, sizeof(*event));
+      rdma_ack_cm_event(event);
+
+      if (event_copy.event == RDMA_CM_EVENT_CONNECT_REQUEST)
+        OnConnectRequest(event_copy.id);
+      else if (event_copy.event == RDMA_CM_EVENT_ADDR_RESOLVED)
+        OnAddrResolved(event_copy.id);
+      else if (event_copy.event == RDMA_CM_EVENT_ROUTE_RESOLVED)
+        OnRouteResolved(event_copy.id);
+      else if (event_copy.event == RDMA_CM_EVENT_ESTABLISHED)
+        OnConnected(event_copy.id);
+      else if (event_copy.event == RDMA_CM_EVENT_DISCONNECTED)
+        OnDisconnected(event_copy.id);
+      else
+        CHECK(0) << "OnEvent: unknown event";
+    }
+  }
+
+  void OnConnectRequest(struct rdma_cm_id *id) {
+    struct rdma_conn_param cm_params;
+    InitConnection(id, false);
+
+    BuildConnection(id, false);
+    BuildConnParam(&cm_params);
+    CHECK(rdma_accept(id, &cm_params) == 0) << "accept RDMA connection failed";
+  }
+
+  void OnAddrResolved(struct rdma_cm_id *id) {
+    BuildConnection(id, true);
+    CHECK(rdma_resolve_route(id, kTimeoutms) == 0) << "resolve RDMA route failed";
+  }
+
+  void OnRouteResolved(struct rdma_cm_id *id) {
+    struct rdma_conn_param cm_params;
+    BuildConnParam(&cm_params);
+    CHECK(rdma_connect(id, &cm_params) == 0) << "RDMA connect failed";
+  }
+
+  void OnConnected(struct rdma_cm_id *id) {
+    struct connection *conn = (struct connection *)id->context;
+    conn->connected = 1;
+  }
+
+  void OnDisconnected(struct rdma_cm_id *id) {
+    struct connection *conn = (struct connection *)id->context;
+    rdma_destroy_qp(id);
+
+    ibv_dereg_mr(conn->send_msg_mr);
+    ibv_dereg_mr(conn->recv_msg_mr);
+
+    free(conn->send_msg);
+    free(conn->recv_msg);
+
+    free(conn);
+    rdma_destroy_id(id);
+  }
+
+  void BuildContext(struct ibv_context *verbs) {
+    if (context_) {
+      CHECK(context_->ctx == verbs) << "cannot handle events in more than one context";
+      context_->cnt++;
+      CHECK_EQ(ibv_resize_cq(context_->cq, context_->cnt * (kRxDepth + kTxDepth)), 0);
+      return;
+    }
+
+    context_ = (struct context *)malloc(sizeof(struct context));
+    context_->ctx = verbs;
+
+    context_->pd = ibv_alloc_pd(context_->ctx);
+    CHECK(context_->pd) << "allocate protected domain failed";
+    NICAllocator::GetNICAllocator()->set_pd(context_->pd);
+
+    context_->cnt = 1;
+    context_->cq = ibv_create_cq(context_->ctx, kRxDepth + kTxDepth, nullptr, nullptr, 0);
+    CHECK(context_->cq) << "create completion queue failed";
+
+    /* register data memory region */
+    context_->rdma_mr = ibv_reg_mr(context_->pd, NICAllocator::GetNICAllocator()->ptr(),
+                                   kDefaultSize, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+    CHECK(context_->rdma_mr) << "register region failed";
+
+    cq_poller_should_stop_ = false;
+    cq_poller_thread_ = new std::thread(&RDMAVan::PollCQ, this);
+  }
+
+  /* register control message region */
+  void RegisterMemory(struct connection *conn) {
+    int rdma_msg_size = sizeof(struct rdma_msg);
+
+    conn->send_msg = (struct rdma_msg *)malloc(rdma_msg_size);
+    conn->send_msg_mr =
+        ibv_reg_mr(context_->pd, conn->send_msg, rdma_msg_size, IBV_ACCESS_LOCAL_WRITE);
+    CHECK(conn->send_msg_mr) << "register send_msg region failed";
+
+    conn->recv_msg = (struct rdma_msg *)malloc(rdma_msg_size);
+    conn->recv_msg_mr =
+        ibv_reg_mr(context_->pd, conn->recv_msg, rdma_msg_size, IBV_ACCESS_LOCAL_WRITE);
+    CHECK(conn->recv_msg_mr) << "register recv_msg region failed";
+  }
+
+  void PostSendRDMAMsg(struct connection *conn, int send_flags = 0) {
+    struct ibv_send_wr wr, *bad_wr = nullptr;
+    struct ibv_sge sge;
+
+    memset(&wr, 0, sizeof(wr));
+
+    wr.wr_id = (uintptr_t)conn;
+    wr.opcode = IBV_WR_SEND;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.send_flags = send_flags;
+
+    sge.addr = (uintptr_t)conn->send_msg;
+    sge.length = sizeof(struct rdma_msg);
+    sge.lkey = conn->send_msg_mr->lkey;
+
+    while (conn->sr_slots >= kTxDepth - 1) {
+    }
+    conn->sr_slots++;
+    CHECK(ibv_post_send(conn->qp, &wr, &bad_wr) == 0)
+        << "send RDMA message failed with errno: " << errno;
+  }
+
+  void PostRecvRDMAMsg(struct connection *conn, int n) {
+    struct ibv_recv_wr *bad_wr = nullptr;
+    struct ibv_recv_wr wr;
+    struct ibv_sge sge;
+
+    wr.wr_id = (uintptr_t)conn;
+    wr.next = nullptr;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+
+    sge.addr = (uintptr_t)conn->recv_msg;
+    sge.length = sizeof(struct rdma_msg);
+    sge.lkey = conn->recv_msg_mr->lkey;
+
+    for (int i = 0; i < n; i++)
+      CHECK(ibv_post_recv(conn->qp, &wr, &bad_wr) == 0)
+          << "post receive MSG failed with errno: " << errno;
+  }
+
+  void PollRDMAMsg(struct ibv_cq *cq, struct ibv_wc *wc) {
+    while (1) {
+      int ret = 0;
+      while ((ret = ibv_poll_cq(cq, 1, wc)) == 0) {
+      }
+      CHECK(ret >= 0) << "error happens in ibv_poll_cq";
+      CHECK(wc->status == IBV_WC_SUCCESS)
+          << "the worker completion status is not ibv_wc_success, but " << wc->status;
+      struct connection *conn = (struct connection *)wc->wr_id;
+      if (wc->opcode == IBV_WC_RECV) {
+        if (--conn->rr_slots <= 1) {
+          PostRecvRDMAMsg(conn, kRxDepth - conn->rr_slots);
+          conn->rr_slots = kRxDepth;
+        }
+        return;
+      }
+      if (wc->opcode == IBV_WC_SEND || wc->opcode == IBV_WC_RDMA_WRITE) conn->sr_slots--;
+    }
+  }
+
+  void BuildConnection(struct rdma_cm_id *id, bool active) {
+    struct connection *conn = (struct connection *)id->context;
+
+    BuildContext(id->verbs);
+
+    conn->cq = !active ? context_->cq
+                       : ibv_create_cq(context_->ctx, kRxDepth + kTxDepth, nullptr, nullptr, 0);
+
+    CHECK(conn->cq) << "create completion queue failed";
+    CHECK(ibv_req_notify_cq(conn->cq, 0) == 0)
+        << "request notification from completion queue failed";
+
+    struct ibv_qp_init_attr qp_attr;
+    memset(&qp_attr, 0, sizeof(struct ibv_qp_init_attr));
+    qp_attr.send_cq = conn->cq;
+    qp_attr.recv_cq = conn->cq;
+    qp_attr.qp_type = IBV_QPT_RC;
+    qp_attr.cap.max_send_wr = kTxDepth;
+    qp_attr.cap.max_recv_wr = kRxDepth;
+    qp_attr.cap.max_send_sge = kSGEntry;
+    qp_attr.cap.max_recv_sge = kSGEntry;
+    qp_attr.sq_sig_all = 0;
+
+    CHECK(rdma_create_qp(id, context_->pd, &qp_attr) == 0) << "create RDMA queue pair failed";
+    conn->qp = id->qp;
+
+    RegisterMemory(conn);
+
+    conn->sr_slots = 0;
+    conn->rr_slots = kRxDepth;
+    PostRecvRDMAMsg(conn, kRxDepth);
+  }
+
+  void BuildConnParam(struct rdma_conn_param *param) {
+    memset(param, 0, sizeof(*param));
+    param->retry_count = 7;
+    param->rnr_retry_count = 7;
+  }
+
+  struct rdma_cm_event *event_ = nullptr;
+  struct rdma_cm_id *listener_ = nullptr;
+  std::unordered_map<int, rdma_cm_id *> connections_;
+
+  struct rdma_event_channel *event_channel_ = nullptr;
+
+  bool event_poller_should_stop_ = false;
+  std::thread *rdma_cm_event_poller_thread_;
+
+  ThreadsafeQueue<struct rdma_msg> write_done_queue_;
+  bool cq_poller_should_stop_ = false;
+  std::thread *cq_poller_thread_;
+
+  std::mutex s_send_mutex_;
+
+  struct context *context_ = nullptr;
+};
+
+};  // namespace ps
+
+#endif  // MXNET_USE_RDMA
+#endif  // PS_RDMA_VAN_H_

--- a/src/rdma_van.h
+++ b/src/rdma_van.h
@@ -94,10 +94,12 @@ class RDMAVan : public Van {
 
  protected:
   void Start(int customer_id) override {
+    start_mu_.lock();
     event_channel_ = rdma_create_event_channel();
     CHECK(event_channel_) << "create RDMA event channel failed";
     event_poller_should_stop_ = false;
     rdma_cm_event_poller_thread_ = new std::thread(&RDMAVan::OnEvent, this);
+    start_mu_.unlock();
     Van::Start(customer_id);
   }
 

--- a/src/rdma_van.h
+++ b/src/rdma_van.h
@@ -95,10 +95,12 @@ class RDMAVan : public Van {
  protected:
   void Start(int customer_id) override {
     start_mu_.lock();
-    event_channel_ = rdma_create_event_channel();
-    CHECK(event_channel_) << "create RDMA event channel failed";
-    event_poller_should_stop_ = false;
-    rdma_cm_event_poller_thread_ = new std::thread(&RDMAVan::OnEvent, this);
+    if (event_channel_ == nullptr) {
+      event_channel_ = rdma_create_event_channel();
+      CHECK(event_channel_) << "create RDMA event channel failed";
+      event_poller_should_stop_ = false;
+      rdma_cm_event_poller_thread_ = new std::thread(&RDMAVan::OnEvent, this);
+    }
     start_mu_.unlock();
     Van::Start(customer_id);
   }

--- a/src/van.cc
+++ b/src/van.cc
@@ -419,12 +419,12 @@ void Van::Receiving() {
 void Van::PackMetaPB(const Meta& meta, PBMeta *pb) {
   pb->set_head(meta.head);
   if (meta.app_id != Meta::kEmpty) pb->set_app_id(meta.app_id);
-  if (meta.customer_id != Meta::kEmpty) pb->set_customer_id(meta.customer_id);
   if (meta.timestamp != Meta::kEmpty) pb->set_timestamp(meta.timestamp);
   if (meta.body.size()) pb->set_body(meta.body);
   pb->set_push(meta.push);
   pb->set_request(meta.request);
   pb->set_simple_app(meta.simple_app);
+  pb->set_customer_id(meta.customer_id);
   for (auto d : meta.data_type) pb->add_data_type(d);
   if (!meta.control.empty()) {
     auto ctrl = pb->mutable_control();
@@ -441,6 +441,7 @@ void Van::PackMetaPB(const Meta& meta, PBMeta *pb) {
       p->set_port(n.port);
       p->set_hostname(n.hostname);
       p->set_is_recovery(n.is_recovery);
+      p->set_customer_id(n.customer_id);
     }
   }
   pb->set_data_size(meta.data_size);

--- a/src/van.cc
+++ b/src/van.cc
@@ -418,6 +418,7 @@ void Van::Receiving() {
 
 void Van::PackMetaPB(const Meta& meta, PBMeta *pb) {
   pb->set_head(meta.head);
+  if (meta.app_id != Meta::kEmpty) pb->set_app_id(meta.app_id);
   if (meta.customer_id != Meta::kEmpty) pb->set_customer_id(meta.customer_id);
   if (meta.timestamp != Meta::kEmpty) pb->set_timestamp(meta.timestamp);
   if (meta.body.size()) pb->set_body(meta.body);

--- a/src/zmq_van.h
+++ b/src/zmq_van.h
@@ -126,7 +126,7 @@ class ZMQVan : public Van {
     void *socket = it->second;
 
     // send meta
-    int meta_size; char* meta_buf;
+    int meta_size; char* meta_buf = nullptr;
     PackMeta(msg.meta, &meta_buf, &meta_size);
     int tag = ZMQ_SNDMORE;
     int n = msg.data.size();

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -4,7 +4,7 @@ TEST = $(patsubst tests/test_%.cc, tests/test_%, $(TEST_SRC))
 # -ltcmalloc_and_profiler
 LDFLAGS = -Wl,-rpath,$(DEPS_PATH)/lib $(PS_LDFLAGS_SO) -pthread
 tests/% : tests/%.cc build/libps.a
-	$(CXX) -std=c++0x $(CFLAGS) -MM -MT tests/$* $< >tests/$*.d
-	$(CXX) -std=c++0x $(CFLAGS) -o $@ $(filter %.cc %.a, $^) $(LDFLAGS)
+	$(CXX) -std=c++0x $(CFLAGS) $(LIBS) -MM -MT tests/$* $< >tests/$*.d
+	$(CXX) -std=c++0x $(CFLAGS) $(LIBS) -o $@ $(filter %.cc %.a, $^) $(LDFLAGS)
 
 -include tests/*.d

--- a/tests/test_kv_app.cc
+++ b/tests/test_kv_app.cc
@@ -1,4 +1,6 @@
 #include "ps/ps.h"
+#include <cmath>
+
 using namespace ps;
 
 void StartServer() {
@@ -41,7 +43,7 @@ void RunWorker() {
 
   float res = 0;
   for (int i = 0; i < num; ++i) {
-    res += fabs(rets[i] - vals[i] * repeat);
+    res += std::fabs(rets[i] - vals[i] * repeat);
   }
   CHECK_LT(res / repeat, 1e-5);
   LL << "error: " << res / repeat;

--- a/tests/test_kv_app_benchmark.cc
+++ b/tests/test_kv_app_benchmark.cc
@@ -1,0 +1,71 @@
+#include <chrono>
+#include <cmath>
+#include "ps/ps.h"
+
+using namespace ps;
+
+template <typename Val>
+void EmptyHandler(const KVMeta &req_meta, const KVPairs<Val> &req_data, KVServer<Val> *server) {
+  KVPairs<Val> res;
+  if (req_meta.push) {
+  } else {
+    res.keys = req_data.keys;
+    res.vals.resize(req_data.keys.size());
+  }
+  server->Response(req_meta, res);
+}
+
+void StartServer() {
+  if (!IsServer()) return;
+  auto server = new KVServer<float>(0);
+  server->set_request_handle(EmptyHandler<float>);
+  RegisterExitCallback([server]() { delete server; });
+}
+
+void RunWorker() {
+  if (!IsWorker()) return;
+  KVWorker<float> kv(0, 0);
+
+  // init
+  int num = 1000000;
+  std::vector<Key> keys(num);
+  std::vector<float> vals(num);
+
+  int rank = MyRank();
+  srand(rank + 7);
+  for (int i = 0; i < num; ++i) {
+    keys[i] = kMaxKey / num * i + rank;
+    vals[i] = (rand() % 1000);
+  }
+
+  int repeat = 50;
+
+  // push
+  auto start = std::chrono::high_resolution_clock::now();
+  for (int i = 0; i < repeat; ++i) {
+    kv.Wait(kv.Push(keys, vals));
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+  LL << "num = " << num << ", Push average time cost: " << (end - start).count() / 1e6 << "ms";
+
+  // pull
+  start = std::chrono::high_resolution_clock::now();
+  std::vector<float> rets;
+  for (int i = 0; i < repeat; ++i) {
+    kv.Wait(kv.Pull(keys, &rets));
+  }
+  end = std::chrono::high_resolution_clock::now();
+  LL << "num = " << num << ", Pull average time cost: " << (end - start).count() / 1e6 << "ms";
+}
+
+int main(int argc, char *argv[]) {
+  // setup server nodes
+  StartServer();
+  // start system
+  Start(0);
+  // run worker nodes
+  RunWorker();
+  // stop system
+  Finalize(0, true);
+  return 0;
+}


### PR DESCRIPTION
## Description
 
This pull request enable RDMA over Converged Ethernet support for ps-lite.

In order to send data with RDMA, the data should be put on a registered memory buffer. 
- `src/rdma_van.h` implements `Van` interface with rdma_cm and ibverbs.
- `include/ps/internal/allocator.h` implements the memory allocator to manage this area.
- `bfc_allocator.h` and `bfc_allocator.cc` implements the memory allocation alogrithm which is encapsulated by `allocator.h`.
- Class `SRMem` in `include/ps/srmem.h` provides array-like access method on this region and can be constructed from `SArray` and C-like array.

## Compile & Test
The patch depends on [`libibverbs`](https://www.openfabrics.org/downloads/rdmacm/) and [`librdmacm`](https://git.kernel.org/pub/scm/libs/infiniband/libibverbs.git) and assumes there is a NIC with RDMA support and all drivers are working.
```
make -j $(nproc) USE_RDMA=1
```
and run the binaries under `tests/` with env `DMLC_ENABLE_RDMA=1`

The tests programs should run well on multiple machines.

## Acknowledgement
Thanks @snowzjx for supplying the BFC algorithm, and this allocation algorithm could be replaced by other better or more appropriate algorithms. Thanks @byronyi and @snowzjx for giving many valuable suggestions.

## Comments
The `SArray` currently maintains a shared pointer, and implements zero-copy operation by moving the pointer to userspace data, and allocate and deallocate the memory with `new` and `delete`. Under RDMA and GPU Direct circumstance, the devices(NIC, GPU) need to register its own memory region. The use of `new` and `delete` by `SArray` cannot satisfy the device's memory management requirement. 

Would it be a good idea to pass an extra __allocator__ parameter to `SArray` thus allocation and deallocation can be managed by the device relevant allocator?
