### PR TITLE
Set scheduler‘s host name to be ip address

### DIFF
--- a/src/van.cc
+++ b/src/van.cc
@@ -253,6 +253,16 @@ void Van::Start(int customer_id) {
     // get my node info
     if (is_scheduler_) {
       my_node_ = scheduler_;
+      std::string ip;
+      const char *itf = Environment::Get()->find("DMLC_INTERFACE");
+      std::string interface;
+      if (itf) interface = std::string(itf);
+      if (interface.size()) {
+          GetIP(interface, &ip);
+      } else {
+          GetAvailableInterfaceAndIP(&interface, &ip);
+      }
+      my_node_.hostname = ip;
     } else {
       auto role = is_scheduler_ ? Node::SCHEDULER :
                   (Postoffice::Get()->is_worker() ? Node::WORKER : Node::SERVER);


### PR DESCRIPTION
Dear all,
When I run mxnet distributed learning cluster on kubernetes via dmlc-submit, scheduler cannot bind port successfully by host name of the scheduler.
Detailed description about this problem please access:[https://github.com/dmlc/dmlc-core/pull/328](url)