### PR TITLE
Surport mxnet train distributed  on Kubernetes

### DIFF
--- a/src/zmq_van.h
+++ b/src/zmq_van.h
@@ -68,6 +68,9 @@ class ZMQVan : public Van {
         << "create receiver socket failed: " << zmq_strerror(errno);
     int local = GetEnv("DMLC_LOCAL", 0);
     std::string hostname = node.hostname.empty() ? "*" : node.hostname;
+    if (max_retry == 0) {
+      hostname = "0.0.0.0";
+    }
     std::string addr = local ? "ipc:///tmp/" : "tcp://" + hostname + ":";
     int port = node.port;
     unsigned seed = static_cast<unsigned>(time(NULL)+port);

--- a/src/zmq_van.h
+++ b/src/zmq_van.h
@@ -68,7 +68,8 @@ class ZMQVan : public Van {
         << "create receiver socket failed: " << zmq_strerror(errno);
     int local = GetEnv("DMLC_LOCAL", 0);
     std::string hostname = node.hostname.empty() ? "*" : node.hostname;
-    if (max_retry == 0) {
+    int use_kubernetes = GetEnv("DMLC_USE_KUBERNETES", 0);
+    if (use_kubernetes > 0 && node.role == Node::SCHEDULER) {
       hostname = "0.0.0.0";
     }
     std::string addr = local ? "ipc:///tmp/" : "tcp://" + hostname + ":";


### PR DESCRIPTION
In Kubernetes pod, 	a virtual ip(svc ip) was used for communication. But this virtual ip can't used for bind. 
So we suggest using 0.0.0.0 to bind scheduler port, and use the virtual ip for communication as before.
@mli 