### PR TITLE
Explicitly import cmath

### DIFF
--- a/tests/test_kv_app.cc
+++ b/tests/test_kv_app.cc
@@ -1,3 +1,4 @@
+#include <cmath>
 #include "ps/ps.h"
 using namespace ps;
 

--- a/tests/test_kv_app_multi_workers.cc
+++ b/tests/test_kv_app_multi_workers.cc
@@ -1,3 +1,4 @@
+#include <cmath>
 #include "ps/ps.h"
 using namespace ps;
 


### PR DESCRIPTION
This fixes a build error encountered on Ubuntu 18.04 using GCC.