### PR TITLE
Support worker/server nodes use cluster ip

### DIFF
--- a/src/zmq_van.h
+++ b/src/zmq_van.h
@@ -69,7 +69,7 @@ class ZMQVan : public Van {
     int local = GetEnv("DMLC_LOCAL", 0);
     std::string hostname = node.hostname.empty() ? "*" : node.hostname;
     int use_kubernetes = GetEnv("DMLC_USE_KUBERNETES", 0);
-    if (use_kubernetes > 0 && node.role == Node::SCHEDULER) {
+    if (use_kubernetes > 0) {
       hostname = "0.0.0.0";
     }
     std::string addr = local ? "ipc:///tmp/" : "tcp://" + hostname + ":";


### PR DESCRIPTION
Use 0.0.0.0 to bind all nodes' listening port.
This can make all nodes use cluster ip in kubernetes. 
We can set DMLC_NODE_HOST and DMLC_PS_ROOT_URI with cluster ip when use kubernetes to launch distribute jobs.
@mli 