### PR TITLE
Change google protobuf from v2.5.0 to v3.5.1 in ps-lite

### DIFF
--- a/make/deps.mk
+++ b/make/deps.mk
@@ -1,6 +1,7 @@
 # Install dependencies
 
-URL=https://raw.githubusercontent.com/mli/deps/master/build
+URL1=https://raw.githubusercontent.com/mli/deps/master/build
+URL2=https://github.com/google/protobuf/releases/download/v3.5.1
 ifndef WGET
 WGET = wget
 endif
@@ -8,10 +9,10 @@ endif
 # protobuf
 PROTOBUF = ${DEPS_PATH}/include/google/protobuf/message.h
 ${PROTOBUF}:
-	$(eval FILE=protobuf-2.5.0.tar.gz)
-	$(eval DIR=protobuf-2.5.0)
+	$(eval FILE=protobuf-cpp-3.5.1.tar.gz)
+	$(eval DIR=protobuf-3.5.1)
 	rm -rf $(FILE) $(DIR)
-	$(WGET) $(URL)/$(FILE) && tar --no-same-owner -zxf $(FILE)
+	$(WGET) $(URL2)/$(FILE) && tar --no-same-owner -zxf $(FILE)
 	cd $(DIR) && export CFLAGS=-fPIC && export CXXFLAGS=-fPIC && ./configure -prefix=$(DEPS_PATH) && $(MAKE) && $(MAKE) install
 	rm -rf $(FILE) $(DIR)
 
@@ -22,7 +23,7 @@ ${ZMQ}:
 	$(eval FILE=zeromq-4.1.4.tar.gz)
 	$(eval DIR=zeromq-4.1.4)
 	rm -rf $(FILE) $(DIR)
-	$(WGET) $(URL)/$(FILE) && tar --no-same-owner -zxf $(FILE)
+	$(WGET) $(URL1)/$(FILE) && tar --no-same-owner -zxf $(FILE)
 	cd $(DIR) && export CFLAGS=-fPIC && export CXXFLAGS=-fPIC && ./configure -prefix=$(DEPS_PATH) --with-libsodium=no --with-libgssapi_krb5=no && $(MAKE) && $(MAKE) install
 	rm -rf $(FILE) $(DIR)
 
@@ -32,7 +33,7 @@ ${LZ4}:
 	$(eval FILE=lz4-r129.tar.gz)
 	$(eval DIR=lz4-r129)
 	rm -rf $(FILE) $(DIR)
-	wget $(URL)/$(FILE) && tar --no-same-owner -zxf $(FILE)
+	wget $(URL1)/$(FILE) && tar --no-same-owner -zxf $(FILE)
 	cd $(DIR) && $(MAKE) && PREFIX=$(DEPS_PATH) $(MAKE) install
 	rm -rf $(FILE) $(DIR)
 
@@ -42,7 +43,7 @@ ${CITYHASH}:
 	$(eval FILE=cityhash-1.1.1.tar.gz)
 	$(eval DIR=cityhash-1.1.1)
 	rm -rf $(FILE) $(DIR)
-	wget $(URL)/$(FILE) && tar --no-same-owner -zxf $(FILE)
+	wget $(URL1)/$(FILE) && tar --no-same-owner -zxf $(FILE)
 	cd $(DIR) && ./configure -prefix=$(DEPS_PATH) --enable-sse4.2 && $(MAKE) CXXFLAGS="-g -O3 -msse4.2" && $(MAKE) install
 	rm -rf $(FILE) $(DIR)
 

--- a/src/meta.proto
+++ b/src/meta.proto
@@ -1,6 +1,7 @@
 /**
  *  Copyright (c) 2015 by Contributors
  */
+syntax = "proto2";
 package ps;
 option optimize_for = LITE_RUNTIME;
 


### PR DESCRIPTION
We intend to extend mxnet distributed training by MPI AllReduce. (https://github.com/apache/incubator-mxnet/pull/10696)
We depends upon google protobuf to do message formatting serialization and de-serialization.  But we found the original protobuf (v2.5.1) checked in ps-lite has issue on serialization and de-serialization. (ps-lite doesn't use this functionality.)  So we plan to replace that protobuf with latest v3.5.1.  