### PR TITLE
Refactor CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,15 +34,15 @@ list(APPEND pslite_INCLUDE_DIR_L "${PROJECT_BINARY_DIR}/include/")
 FILE(GLOB SOURCE "src/*.cc")
 
 if(MSVC)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
-FILE(GLOB getopt_SOURCE "src/windows/getopt.c")
-list(APPEND SOURCE ${getopt_SOURCE}) 
-add_definitions(-DSTATIC_GETOPT)
-include_directories(pslite "${PROJECT_SOURCE_DIR}/src/windows")
-list(APPEND pslite_LINKER_LIBS_L "ipHlpApi.lib" "ws2_32.lib")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+  FILE(GLOB getopt_SOURCE "src/windows/getopt.c")
+  list(APPEND SOURCE ${getopt_SOURCE}) 
+  add_definitions(-DSTATIC_GETOPT)
+  include_directories(pslite "${PROJECT_SOURCE_DIR}/src/windows")
+  list(APPEND pslite_LINKER_LIBS_L "ipHlpApi.lib" "ws2_32.lib")
   foreach(flag_var
-        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+      CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+      CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
     if(${flag_var} MATCHES "/MD")
       string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
     endif(${flag_var} MATCHES "/MD")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,45 +1,41 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.1)
 
 project(pslite C CXX)
-
-if(NOT MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-endif()
-
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 
-include(ExternalProject) 
-set(pslite_LINKER_LIBS_L "" )
-set(pslite_LINKER_LIBS_L_RELEASE "" )
-set(pslite_LINKER_LIBS_L_DEBUG "" )
-set(pslite_INCLUDE_DIR_L "" )
+add_library(pslite)
 
 # ---[ zmq
 include("cmake/External/zmq.cmake")
-include_directories(pslite ${ZMQ_INCLUDE_DIRS})
-list(APPEND pslite_LINKER_LIBS_L ${ZMQ_LIBRARIES})
+target_include_directories(pslite PRIVATE ${ZMQ_INCLUDE_DIRS})
+target_link_libraries(pslite PUBLIC ${ZMQ_LIBRARIES})
 # ---[ Google-protobuf
 include(cmake/ProtoBuf.cmake)
+target_link_libraries(pslite PUBLIC ${PROTOBUF_LIBRARY})
+target_include_directories(pslite PUBLIC ${PROTOBUF_INCLUDE_DIR})
+
+FILE(GLOB SOURCE "src/*.cc")
 
 # generate protobuf sources
 set(proto_gen_folder "${PROJECT_BINARY_DIR}/src")
 file(GLOB_RECURSE proto_files "src/*.proto")
 pslite_protobuf_generate_cpp_py(${proto_gen_folder} proto_srcs proto_hdrs proto_python "${PROJECT_SOURCE_DIR}" "src" ${proto_files})
-include_directories(pslite "${PROJECT_SOURCE_DIR}/include/")
-include_directories(pslite "${PROJECT_BINARY_DIR}/include/")
-include_directories(pslite "${PROJECT_BINARY_DIR}/src/")
-list(APPEND pslite_INCLUDE_DIR_L "${PROJECT_BINARY_DIR}/include/")
+list(APPEND SOURCE ${proto_srcs})
 
-#FILE(COPY DIRECTORY "${PROJECT_BINARY_DIR}/include" DESTINATION "${PROJECT_SOURCE_DIR}/" FILES_MATCHING PATTERN "*.pb.h")
-FILE(GLOB SOURCE "src/*.cc")
+target_include_directories(pslite PUBLIC "${PROJECT_SOURCE_DIR}/include/")
+target_include_directories(pslite PUBLIC "${PROJECT_BINARY_DIR}/include/")
+target_include_directories(pslite PRIVATE "${PROJECT_BINARY_DIR}/src/")
 
 if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
   FILE(GLOB getopt_SOURCE "src/windows/getopt.c")
-  list(APPEND SOURCE ${getopt_SOURCE}) 
+  list(APPEND SOURCE ${getopt_SOURCE})
   add_definitions(-DSTATIC_GETOPT)
-  include_directories(pslite "${PROJECT_SOURCE_DIR}/src/windows")
-  list(APPEND pslite_LINKER_LIBS_L "ipHlpApi.lib" "ws2_32.lib")
+  target_include_directories(pslite PRIVATE "${PROJECT_SOURCE_DIR}/src/windows")
+  target_link_libraries(pslite PUBLIC "ipHlpApi.lib" "ws2_32.lib")
   foreach(flag_var
       CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
       CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
@@ -49,27 +45,4 @@ if(MSVC)
   endforeach(flag_var)
 endif()
 
-list(APPEND SOURCE ${proto_srcs}) 
-add_library(pslite ${SOURCE}) 
-
-target_link_libraries(pslite ${pslite_LINKER_LIBS})
-
-# FindProtobuf behavior changed from cmake 3.6 onwards
-IF (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.6)
-  set(PROTO_LIB ${Protobuf_LIBRARY})
-  set(PROTO_LIB_DEBUG ${Protobuf_LIBRARY_DEBUG})
-ELSE (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.6)
-  set(PROTO_LIB ${PROTOBUF_LIBRARY})
-  set(PROTO_LIB_DEBUG ${PROTOBUF_LIBRARY_DEBUG})
-ENDIF (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.6)
-
-list(APPEND pslite_LINKER_LIBS_L_RELEASE ${PROTO_LIB})
-list(APPEND pslite_LINKER_LIBS_L_DEBUG ${PROTO_LIB_DEBUG})
-
-list(APPEND pslite_INCLUDE_DIR_L "${PROJECT_SOURCE_DIR}/include")
-list(APPEND pslite_INCLUDE_DIR_L ${PROTOBUF_INCLUDE_DIR})
-
-set(pslite_LINKER_LIBS ${pslite_LINKER_LIBS_L} PARENT_SCOPE)
-set(pslite_LINKER_LIBS_RELEASE ${pslite_LINKER_LIBS_L_RELEASE} PARENT_SCOPE)
-set(pslite_LINKER_LIBS_DEBUG ${pslite_LINKER_LIBS_L_DEBUG} PARENT_SCOPE)
-set(pslite_INCLUDE_DIR ${pslite_INCLUDE_DIR_L} PARENT_SCOPE)
+target_sources(pslite PRIVATE ${SOURCE})

--- a/cmake/External/zmq.cmake
+++ b/cmake/External/zmq.cmake
@@ -23,6 +23,7 @@ if (NOT __ZMQ_INCLUDED) # guard against multiple includes
     set(ZMQ_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${ZMQ_EXTRA_COMPILER_FLAGS})
     set(ZMQ_C_FLAGS ${CMAKE_C_FLAGS} ${ZMQ_EXTRA_COMPILER_FLAGS})
 
+    include(ExternalProject)
     ExternalProject_Add(ZMQ
       PREFIX ${ZMQ_PREFIX}
       GIT_REPOSITORY "https://github.com/zeromq/libZMQ.git"


### PR DESCRIPTION
This exposes pslite as cmake target, to ease integration into upstream projects.
Current integration is done via a "parent scope hack", that is non-standard and actually removed by some people shipping ps-lite [1].

We require CMake 3.1 released Dec 17, 2014 as it is the first CMake release with proper C++11 support and as ps-lite uses C++11.

I tested the changes by building MXNet with `-DUSE_DIST_KVSTORE` and the updated ps-lite. The following branch was built https://github.com/leezu/mxnet/commits/pslitecmakeupdate

References:
[1] https://github.com/search?l=Diff&q=set%28pslite_LINKER_LIBS+%24%7Bpslite_LINKER_LIBS_L%7D%29&type=Code

CC @yajiedesign @eric-haibin-lin @szha 